### PR TITLE
adding length requirement for nicknames, fixes #69

### DIFF
--- a/packages/language/en/index.ts
+++ b/packages/language/en/index.ts
@@ -61,6 +61,9 @@ export const addANewFriend = 'Add a New Friend'
 export const lndrNickname = 'Lndr Nickname:'
 
 export const accountManagement = {
+  nickname: {
+    lengthViolation: 'Nickname should be at least 3 characters.',
+  },
   password: {
     lengthViolation: 'Password should be at least 8 characters.',
     matchViolation: 'Passwords should match.',

--- a/packages/lndr/engine/index.ts
+++ b/packages/lndr/engine/index.ts
@@ -113,6 +113,11 @@ export default class Engine {
     if (accountData.password !== accountData.confirmPassword) {
       return this.setErrorMessage(accountManagement.password.matchViolation)
     }
+    // TODO what do we want the requirements for nicknames to be?
+    // should whitespace be allowed?
+    if (accountData.nickname.length < 3) {
+      return this.setErrorMessage(accountManagement.nickname.lengthViolation)
+    }
 
     const password = accountData.password
     const mnemonicInstance = creditProtocol.getRandomMnemonic()


### PR DESCRIPTION
- before it was possible to create an account without setting a nick; this is
impossible now.