### PR TITLE
Fix balances color

### DIFF
--- a/packages/ui/components/balance-row/index.tsx
+++ b/packages/ui/components/balance-row/index.tsx
@@ -20,7 +20,7 @@ export default class BalanceRow extends Component<Props> {
     const { amount } = balance
 
     if (amount < 0) {
-      return <Text style={style.titledFactAmountBad}>{cents(amount)}</Text>
+      return <Text style={style.titledFactAmountDanger}>{cents(amount)}</Text>
     }
 
     else {

--- a/packages/ui/views/account/home/index.tsx
+++ b/packages/ui/views/account/home/index.tsx
@@ -121,7 +121,7 @@ export default class HomeView extends Component<Props, State> {
     }
 
     else if (balance < 0) {
-      return <Text style={style.largeFactAmountBad}>{cents(balance)}</Text>
+      return <Text style={style.largeFactAmountDanger}>{cents(balance)}</Text>
     }
 
     else {


### PR DESCRIPTION
- `titledFactAmountBad` & `factAmountBad` referred to non-existent styles, resulted in bad display of neg. balances
- changed these names to point to appropriate styles, s/Bad/Danger/g

note: The ui style code needs to be seriously cleaned up. Lots of bad var names like `goodDark`...