### PR TITLE
Feature unique salt

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "assert": "^1.4.1",
+    "bcryptjs": "^2.4.3",
     "bitcore-mnemonic": "^1.5.0",
     "ethereumjs-util": "^5.1.2",
     "events": "^1.1.1",

--- a/packages/lndr/engine/index.ts
+++ b/packages/lndr/engine/index.ts
@@ -17,10 +17,13 @@ import Storage from 'lndr/storage'
 
 import { accountManagement, debtManagement } from 'language'
 
+const bcrypt = require('bcryptjs')
+
 const mnemonicStorage = new Storage('mnemonic')
 const hashedPasswordStorage = new Storage('hashed-password')
 
 export const PASSWORD_SALT = 'THIS_IS_A_SALT_5426892348596723645879243876'
+export const SALT_SIZE = 10
 
 const creditProtocol = new CreditProtocol('http://34.238.20.130')
 
@@ -424,6 +427,11 @@ export default class Engine {
     catch (e) {
       this.setErrorMessage(debtManagement.pending.error)
     }
+  }
+
+  generateHashedPassword(password) {
+     const salt = bcrypt.genSaltSync(SALT_SIZE)
+     return bcrypt.hashSync(password, salt)
   }
 
   createUserFromCredentials(mnemonicInstance, password, hashed = '') {

--- a/packages/ui/forms/recover-account/index.tsx
+++ b/packages/ui/forms/recover-account/index.tsx
@@ -34,7 +34,7 @@ export default class RecoverAccountForm extends Component<Props, RecoverAccountD
         multiline
         style={style.multilineTextInput}
         placeholder={recoverMnemonic}
-        onChangeText={mnemonic => this.setState({ mnemonic })}
+        onChangeText={mnemonic => this.setState({ mnemonic: mnemonic.trim() })}
       />
       <TextInput
         secureTextEntry


### PR DESCRIPTION
- decoupled mnemonic & password in seeding generation of HD private key
- incorporated salts in password
   + salt stored as part of hashed password, no separate salt storage is necessary
- trimming mnemonic input to handle leading and trailing whitespace

NOTE: if this version of the app is used, previously-stored mnemonics will not generate the same accounts. It will be necessary to make new accounts