### PR TITLE
Feature - Hide remove friend button that have balances

### DIFF
--- a/packages/ui/views/account/friends/remove-friend/index.tsx
+++ b/packages/ui/views/account/friends/remove-friend/index.tsx
@@ -82,7 +82,7 @@ export default class RemoveFriend extends Component<Props, State> {
       <Text style={formStyle.text}>{friendInfo}</Text>
         <Loading context={loadingContext} />
         { this.renderBalanceRow() }
-        <Button danger onPress={() => this.removeFriend(friend)} text={removeFriend} />
+        { this.state.balance.amount === 0 && <Button danger onPress={() => this.removeFriend(friend)} text={removeFriend} /> }
         <Button alternate onPress={closePopup} text={back} />
     </View>
   }


### PR DESCRIPTION
Why:

* We do not want to remove any friends with balances

This change addresses the need by:

* Add conditional to only render remove friend button when balance is 0


PLEASE NOTE - I could not test this since I don't have a dollar amount to test this. I hacked the render to show this, but we need to test this with actual data, before merging.