### PR TITLE
Feature - Authentication Loading

### DIFF
--- a/packages/lndr/engine/index.ts
+++ b/packages/lndr/engine/index.ts
@@ -28,6 +28,7 @@ const creditProtocol = new CreditProtocol('http://34.238.20.130')
 export interface EngineState {
   user?: User,
   isInitializing?: boolean
+  isAuthLoading?: boolean
   hasStoredUser?: boolean
   shouldRecoverAccount?: boolean
   shouldRemoveAccount?: boolean
@@ -56,6 +57,7 @@ export default class Engine {
     this.engineState = {
       hasStoredUser: false,
       welcomeComplete: false,
+      isAuthLoading: false,
       shouldRecoverAccount: false,
       shouldRemoveAccount: false,
       shouldDisplayMnemonic: false
@@ -520,6 +522,10 @@ export default class Engine {
     await mnemonicStorage.remove()
     await hashedPasswordStorage.remove()
     this.state = { hasStoredUser: false, shouldRemoveAccount: false }
+  }
+
+  setAuthLoading(state) {
+    this.state = { isAuthLoading: state }
   }
 
   goToRecoverAccount() {

--- a/packages/ui/views/app/index.tsx
+++ b/packages/ui/views/app/index.tsx
@@ -77,6 +77,7 @@ export default class AppView extends Component<Props, EngineState> {
       user,
       mnemonicInstance,
       isInitializing,
+      isAuthLoading,
       hasStoredUser,
       welcomeComplete,
       shouldRecoverAccount,
@@ -97,6 +98,7 @@ export default class AppView extends Component<Props, EngineState> {
       return <AuthenticateView
         engine={engine}
         mnemonic={mnemonicInstance ? mnemonicInstance.toString() : null}
+        isAuthLoading={isAuthLoading}
         shouldRecoverAccount={shouldRecoverAccount}
         shouldRemoveAccount={shouldRemoveAccount}
         shouldDisplayMnemonic={shouldDisplayMnemonic}

--- a/packages/ui/views/authenticate/create-account/index.tsx
+++ b/packages/ui/views/authenticate/create-account/index.tsx
@@ -6,19 +6,28 @@ import Engine from 'lndr/engine'
 
 import CreateAccountForm from 'ui/forms/create-account'
 
+import { CreateAccountData } from 'lndr/user'
+
 interface Props {
   engine: Engine
 }
 
 export default class CreateAccountView extends Component<Props> {
+  async handleOnSubmitCreateAccount(formData: CreateAccountData) {
+    await this.props.engine.setAuthLoading(true)
+    await this.props.engine.createAccount(formData)
+    this.props.engine.setAuthLoading(false)
+  }
+
   render() {
     const { engine } = this.props
-
-    return <View>
-      <CreateAccountForm
-        onSubmitCreateUser={formData => engine.createAccount(formData)}
-        onSubmitRecover={() => engine.goToRecoverAccount()}
-      />
-    </View>
+    return (
+      <View>
+        <CreateAccountForm
+          onSubmitCreateUser={this.handleOnSubmitCreateAccount.bind(this)}
+          onSubmitRecover={() => engine.goToRecoverAccount()}
+        />
+      </View>
+    )
   }
 }

--- a/packages/ui/views/authenticate/index.tsx
+++ b/packages/ui/views/authenticate/index.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 
-import { ScrollView } from 'react-native'
+import { View, ActivityIndicator, ScrollView } from 'react-native'
 
 import Engine from 'lndr/engine'
 
@@ -17,9 +17,12 @@ import ConfirmAccountView from './confirm-account'
 import general from 'theme/general'
 import style from 'theme/authenticate'
 
+import loadingStyle from 'theme/loading'
+
 interface Props {
   engine: Engine,
   hasStoredUser?: boolean
+  isAuthLoading?: boolean
   shouldRecoverAccount?: boolean
   shouldRemoveAccount?: boolean
   shouldDisplayMnemonic?: boolean
@@ -32,8 +35,21 @@ export default class AuthenticateView extends Component<Props> {
       <FadeInView style={style.main}>
         <ThemeImage name='logo' />
         {this.renderView()}
+        {this.renderLoadingView()}
       </FadeInView>
     </ScrollView>
+  }
+
+  renderLoadingView() {
+    const { isAuthLoading } = this.props
+    if (isAuthLoading === true) {
+      return (
+        <View style={loadingStyle.loading}>
+          <ActivityIndicator size='large' />
+        </View>
+      )
+    }
+    return null
   }
 
   renderView() {

--- a/packages/ui/views/authenticate/recover-account/index.tsx
+++ b/packages/ui/views/authenticate/recover-account/index.tsx
@@ -6,17 +6,25 @@ import Engine from 'lndr/engine'
 
 import RecoverAccountForm from 'ui/forms/recover-account'
 
+import { RecoverAccountData } from 'lndr/user'
+
 interface Props {
   engine: Engine
 }
 
 export default class RecoverAccountView extends Component<Props> {
+  async handleOnSubmitRecoverUser(formData: RecoverAccountData) {
+    await this.props.engine.setAuthLoading(true)
+    await this.props.engine.recoverAccount(formData)
+    this.props.engine.setAuthLoading(false)
+  }
+
   render() {
     const { engine } = this.props
     return (
       <View>
         <RecoverAccountForm
-          onSubmitRecoverUser={formData => engine.recoverAccount(formData)}
+          onSubmitRecoverUser={this.handleOnSubmitRecoverUser.bind(this)}
           onCancel={() => engine.cancelRecoverAccount()}
         />
       </View>


### PR DESCRIPTION
Why:

* We want to show Activity Indicator when the user is recovering their
login or creating a new account

This change addresses the need by:

* Add a new isAuthLoading key to the engine state
* Create a setter for that key in engine
* Pass isAuthLoading down to the authenticate view
* Wrap the createAccount/recoverAccount calls using the new flag