### PR TITLE
Feature - Add Copy for mnemonic

### DIFF
--- a/packages/language/en/index.ts
+++ b/packages/language/en/index.ts
@@ -7,6 +7,7 @@ export const submit = 'Submit'
 export const next = 'Next'
 export const cancel = 'Cancel'
 export const back = 'Go Back'
+export const copy = 'Copy to Clipboard'
 
 export const confirmAccount = 'Confirm'
 export const createAccount = 'Create Account'

--- a/packages/ui/dialogs/my-account/index.tsx
+++ b/packages/ui/dialogs/my-account/index.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 
 import { defaultUpdateAccountData } from 'lndr/user'
 
-import { Text, TextInput, View } from 'react-native'
+import { Text, TextInput, View, Clipboard } from 'react-native'
 
 import Engine from 'lndr/engine'
 import Button from 'ui/components/button'
@@ -12,7 +12,7 @@ const loadingContext = new LoadingContext()
 
 import style from 'theme/form'
 
-import { nickname, setNickname, updateAccount, cancel, mnemonicExhortation } from 'language'
+import { nickname, setNickname, updateAccount, copy, cancel, mnemonicExhortation } from 'language'
 
 interface Props {
   engine: Engine,
@@ -53,6 +53,7 @@ export default class MyAccount extends Component<Props, State> {
       <Loading context={loadingContext} />
       <Text style={style.text}>{mnemonicExhortation}</Text>
       <Text selectable style={style.displayText}>{user.mnemonic}</Text>
+      <Button icon='md-copy' onPress={() => Clipboard.setString(user.mnemonic)} text={copy} />
       <Text style={style.text}>{setNickname}</Text>
       <TextInput
         autoCapitalize='none'

--- a/packages/ui/views/authenticate/confirm-account/index.tsx
+++ b/packages/ui/views/authenticate/confirm-account/index.tsx
@@ -1,12 +1,12 @@
 import React, { Component } from 'react'
 
-import { View, Text } from 'react-native'
+import { View, Text, Clipboard } from 'react-native'
 
 import Engine from 'lndr/engine'
 
 import Button from 'ui/components/button'
 
-import { next, mnemonicExhortation } from 'language'
+import { next, copy, mnemonicExhortation } from 'language'
 
 import style from 'theme/form'
 
@@ -23,6 +23,7 @@ export default class RecoverAccountView extends Component<Props> {
       <View style={style.form}>
         <Text style={style.header}>{mnemonicExhortation}</Text>
         <Text selectable style={style.displayText}>{mnemonic}</Text>
+        <Button icon='md-copy' onPress={() => Clipboard.setString(mnemonic)} text={copy} />
         <Button onPress={() => engine.mnemonicDisplayed()} text={next} />
       </View>
     )


### PR DESCRIPTION
Why:

* We need to be able to copy the mnemonic text so that the user can
easily paste the words in a password manager

This change addresses the need by:

* Add Copy button for my account view
* Add Copy button for confirm account view
* Add lanuage const for copy text