### PR TITLE
Feature - Cancel pending transactions that the user owns

### DIFF
--- a/packages/ui/dialogs/pending-transaction-detail/index.tsx
+++ b/packages/ui/dialogs/pending-transaction-detail/index.tsx
@@ -62,7 +62,10 @@ export default class PendingTransactionDetail extends Component<Props> {
         <Text style={formStyle.text}>
           {pendingTransactionsLanguage.pendingAnnouncement}
         </Text>
-        <Button style={formStyle.lastButton} onPress={closePopup} text={back} />
+        <View style={style.listItem}>
+          <Button containerStyle={formStyle.leftButton} danger onPress={() => this.rejectPendingTransaction(pendingTransaction)} text={cancel} />
+          <Button containerStyle={formStyle.rightButton} onPress={closePopup} text={back} />
+        </View>
       </View>
     }
 


### PR DESCRIPTION
Why:

* We need the ability to cancel any pending transaction if the user
created it on accident/incorrectly

This change addresses the need by:

* Adding the reject/cancel option to the popup modal when opening the
activity