### PR TITLE
Feature - Login Duplication Check

### DIFF
--- a/packages/credit-protocol/index.ts
+++ b/packages/credit-protocol/index.ts
@@ -77,6 +77,10 @@ export default class CreditProtocol {
     return this.client.get(`/search_nick/${nick}`)
   }
 
+  takenNick(nick: string) {
+    return this.client.get(`/taken_nick/${nick}`)
+  }
+
   addFriend(user: string, addr: string/*, privateKeyBuffer: any*/) {
     return this.client.post(`/add_friends/${user}`, [ addr ])
     // {

--- a/packages/language/en/index.ts
+++ b/packages/language/en/index.ts
@@ -62,7 +62,8 @@ export const lndrNickname = 'Lndr Nickname:'
 export const accountManagement = {
   nickname: {
     lengthViolation: 'Nickname should be at least 3 characters.',
-    compositionViolation: 'Nickname can contain only numbers and lowercase letters.'
+    compositionViolation: 'Nickname can contain only numbers and lowercase letters.',
+    duplicationViolation: 'Nickname is already taken'
   },
   password: {
     lengthViolation: 'Password should be at least 8 characters.',

--- a/packages/lndr/engine/index.ts
+++ b/packages/lndr/engine/index.ts
@@ -225,6 +225,14 @@ export default class Engine {
     }
   }
 
+  async takenNick(nickname: string) {
+    let result = false
+    if (nickname.length >= minimumNicknameLength) {
+      result = await creditProtocol.takenNick(nickname)
+    }
+    return result
+  }
+
   async addFriend(friend: Friend) {
   const { address/*, privateKeyBuffer*/ } = this.user
     try {

--- a/packages/ui/forms/create-account/index.tsx
+++ b/packages/ui/forms/create-account/index.tsx
@@ -18,6 +18,8 @@ import {
 import style from 'theme/form'
 
 interface Props {
+  onNickTextInputBlur: (nickname: string) => void
+  nickTextInputErrorText: string
   onSubmitCreateUser: (formData: CreateAccountData) => void
   onSubmitRecover: () => void
 }
@@ -29,6 +31,7 @@ export default class CreateAccountForm extends Component<Props, CreateAccountDat
   }
 
   render() {
+    const { onNickTextInputBlur, nickTextInputErrorText } = this.props
     return <View style={style.form}>
       <Text style={style.text}>{newAccount}</Text>
       <TextInput
@@ -37,7 +40,9 @@ export default class CreateAccountForm extends Component<Props, CreateAccountDat
         placeholder={nickname}
         value={this.state.nickname}
         onChangeText={nickname => this.setState({ nickname })}
+        onBlur={(): void => onNickTextInputBlur(this.state.nickname)}
       />
+      { nickTextInputErrorText && <Text style={style.warningText}>{nickTextInputErrorText}</Text>}
       <TextInput
         secureTextEntry
         style={style.textInput}

--- a/packages/ui/forms/login-account/index.tsx
+++ b/packages/ui/forms/login-account/index.tsx
@@ -26,10 +26,6 @@ export default class LoginAccountForm extends Component<Props, LoginAccountData>
     this.state = defaultLoginAccountData()
   }
 
-  componentDidMount() {
-    // this.props.onSubmit({ confirmPassword: 'testtest' })
-  }
-
   render() {
     const { onSubmit, onRemoveAccount } = this.props
     return <View style={style.form}>

--- a/packages/ui/views/authenticate/create-account/index.tsx
+++ b/packages/ui/views/authenticate/create-account/index.tsx
@@ -8,15 +8,47 @@ import CreateAccountForm from 'ui/forms/create-account'
 
 import { CreateAccountData } from 'lndr/user'
 
+import { accountManagement } from 'language'
+
 interface Props {
   engine: Engine
 }
 
-export default class CreateAccountView extends Component<Props> {
+interface AccountViewState {
+  duplicationViolation?: boolean
+}
+
+const defaultAccountViewState = (): AccountViewState => ({
+  duplicationViolation: false
+})
+
+export default class CreateAccountView extends Component<Props, AccountViewState> {
+  constructor() {
+    super()
+    this.state = defaultAccountViewState()
+  }
+
   async handleOnSubmitCreateAccount(formData: CreateAccountData) {
     await this.props.engine.setAuthLoading(true)
     await this.props.engine.createAccount(formData)
     this.props.engine.setAuthLoading(false)
+  }
+
+  async handleOnNickTextInputBlur(nickname: string) {
+    const duplicateNick = await this.props.engine.takenNick(nickname)
+    if (duplicateNick) {
+      this.setState({ duplicationViolation: true })
+    } else {
+      this.setState({ duplicationViolation: false })
+    }
+  }
+
+  renderNickTextInputErrorText() {
+    let errorText
+    if (this.state.duplicationViolation) {
+      errorText = accountManagement.nickname.duplicationViolation
+    }
+    return errorText
   }
 
   render() {
@@ -24,6 +56,8 @@ export default class CreateAccountView extends Component<Props> {
     return (
       <View>
         <CreateAccountForm
+          nickTextInputErrorText={this.renderNickTextInputErrorText()}
+          onNickTextInputBlur={this.handleOnNickTextInputBlur.bind(this)}
           onSubmitCreateUser={this.handleOnSubmitCreateAccount.bind(this)}
           onSubmitRecover={() => engine.goToRecoverAccount()}
         />

--- a/packages/ui/views/authenticate/login/index.tsx
+++ b/packages/ui/views/authenticate/login/index.tsx
@@ -8,8 +8,6 @@ import LoginAccountForm from 'ui/forms/login-account'
 
 import { LoginAccountData } from 'lndr/user'
 
-import Popup from 'ui/components/popup'
-
 interface Props {
   engine: Engine
 }


### PR DESCRIPTION
Why:

* We want to check to see if there is a duplicate nick being created
when the user signs up

This change addresses the need by:

* Add taken_nick endpoint
* Apply endpoint to engine
* Update create account form view to house a state for invalid
duplication
* Pass a error text when there is a duplication state detected to the
form
* Update Text in lanuage for duplication error