### PR TITLE
Feature - Register Channel Id

### DIFF
--- a/packages/credit-protocol/index.ts
+++ b/packages/credit-protocol/index.ts
@@ -77,6 +77,10 @@ export default class CreditProtocol {
     return this.client.get(`/search_nick/${nick}`)
   }
 
+  registerChannelID(user: string, channelID: string, platform: string) {
+    return this.client.post(`/register_push/${user}`, { channelID, platform })
+  }
+
   takenNick(nick: string) {
     return this.client.get(`/taken_nick/${nick}`)
   }

--- a/packages/lndr/engine/index.ts
+++ b/packages/lndr/engine/index.ts
@@ -2,6 +2,7 @@
 
 import ethUtil from 'ethereumjs-util'
 import { UrbanAirship } from 'urbanairship-react-native'
+import { Platform } from 'react-native';
 
 import { longTimePeriod } from 'lndr/time'
 import Balance from 'lndr/balance'
@@ -74,13 +75,15 @@ export default class Engine {
   }
 
   initalizePushNotifications() {
+    if (!this.state.hasStoredUser) {
+      return
+    }
     UrbanAirship.setUserNotificationsEnabled(true)
     UrbanAirship.addListener("register", (event) => {
-      console.log('Channel registration updated: ', event.channelId);
-      console.log('Registration token: ', event.registrationToken);
+      this.registerChannelID(event.channelId, Platform.OS)
     });
     UrbanAirship.addListener("pushReceived", (notification) => {
-        console.log('Received push: ', JSON.stringify(notification));
+      console.log('Received push: ', JSON.stringify(notification));
     });
     UrbanAirship.setForegroundPresentationOptions({
       alert: true,
@@ -231,6 +234,11 @@ export default class Engine {
       result = await creditProtocol.takenNick(nickname)
     }
     return result
+  }
+
+  registerChannelID(channelID: string, platform: string) {
+    const { address } = this.user
+    creditProtocol.registerChannelID(address, channelID, platform)
   }
 
   async addFriend(friend: Friend) {

--- a/packages/ui/views/account/index.tsx
+++ b/packages/ui/views/account/index.tsx
@@ -30,6 +30,11 @@ export default class AccountView extends Component<Props> {
   pending: any
   tabs: any
 
+  constructor(props) {
+    super(props)
+    props.engine.initalizePushNotifications()
+  }
+
   getPendingBadge() {
     const { pendingTransactionsCount } = this.props
 

--- a/packages/ui/views/app/index.tsx
+++ b/packages/ui/views/app/index.tsx
@@ -27,7 +27,6 @@ export default class AppView extends Component<Props, EngineState> {
     super()
     this.state = engine.state
     engine.subscribe(state => this.setState(state))
-    engine.initalizePushNotifications()
   }
 
   async componentDidMount() {

--- a/packages/ui/views/authenticate/confirm-account/index.tsx
+++ b/packages/ui/views/authenticate/confirm-account/index.tsx
@@ -15,7 +15,7 @@ interface Props {
   mnemonic?: string
 }
 
-export default class RecoverAccountView extends Component<Props> {
+export default class ConfirmAccountView extends Component<Props> {
   render() {
     const { engine, mnemonic } = this.props
 
@@ -23,7 +23,7 @@ export default class RecoverAccountView extends Component<Props> {
       <View style={style.form}>
         <Text style={style.header}>{mnemonicExhortation}</Text>
         <Text selectable style={style.displayText}>{mnemonic}</Text>
-        <Button icon='md-copy' onPress={() => Clipboard.setString(mnemonic)} text={copy} />
+        <Button icon='md-copy' onPress={() => Clipboard.setString(mnemonic ? mnemonic : ' ')} text={copy} />
         <Button onPress={() => engine.mnemonicDisplayed()} text={next} />
       </View>
     )


### PR DESCRIPTION
Why:

* We need to push the channel id to the backend such that it can do
urban airship requests for push notifications

This change addresses the need by:

* Move push notification initalizer to the account view
* Add registerChannelID endpoint
* Update urban airship register event to send a request with channel id
 and platform to the backend using the new endpoint

Side Effect:
* Fix a typescript error on confirm-account