### PR TITLE
BugFix - Unable to search users using the @ symbol

### DIFF
--- a/packages/actions/index.ts
+++ b/packages/actions/index.ts
@@ -293,7 +293,10 @@ export const getFriends = () => {
 
 //Not a redux action
 export async function searchUsers(searchData) {
-  const { nickname } = searchData
+  let nickname = searchData.nickname
+  if (nickname.substring(0, 1) === '@') {
+    nickname = nickname.substring(1);
+  }
   if (nickname.length >= minimumNicknameLength) {
     const users = await creditProtocol.searchUsers(nickname)
     return users.map(jsonToFriend)


### PR DESCRIPTION
Why:

* We need to be able to search user with/without the @ symbol in front

This change addresses the need by:

* Update searchUsers function to trim off @ when inputted