### PR TITLE
create account: clear nickname and email address error messages when user changes the text input

### DIFF
--- a/packages/ui/forms/create-account/index.tsx
+++ b/packages/ui/forms/create-account/index.tsx
@@ -35,7 +35,7 @@ const loadingContext = new LoadingContext()
 
 interface Props {
   onNickTextInputBlur: (nickname: string) => void
-  onNickTextChange: (email: string) => void
+  onNickTextChange: (nickname: string) => void
   nickInputError: string
   onEmailTextInputBlur: (email: string) => void
   onEmailTextChange: (email: string) => void

--- a/packages/ui/forms/create-account/index.tsx
+++ b/packages/ui/forms/create-account/index.tsx
@@ -35,8 +35,10 @@ const loadingContext = new LoadingContext()
 
 interface Props {
   onNickTextInputBlur: (nickname: string) => void
+  onNickTextChange: (email: string) => void
   nickInputError: string
   onEmailTextInputBlur: (email: string) => void
+  onEmailTextChange: (email: string) => void
   emailInputError: string
   onSubmitRecover: () => void
   createAccount: (accountData: CreateAccountData) => any
@@ -132,7 +134,8 @@ class CreateAccountForm extends Component<Props, State> {
   }
 
   render() {
-    const { onNickTextInputBlur, nickInputError, onEmailTextInputBlur, emailInputError } = this.props
+    const { onNickTextInputBlur, onNickTextChange, nickInputError,
+      onEmailTextInputBlur, onEmailTextChange, emailInputError } = this.props
     const { password, confirmPassword, step } = this.state
 
     if (step === 4) {
@@ -161,7 +164,7 @@ class CreateAccountForm extends Component<Props, State> {
               value={this.state.nickname}
               maxLength={20}
               underlineColorAndroid='transparent'
-              onChangeText={nickname => this.setState({ nickname: formatNick(nickname) })}
+              onChangeText={nickname => {this.setState({ nickname: formatNick(nickname) }); onNickTextChange(nickname)}}
               onBlur={(): void => onNickTextInputBlur(this.state.nickname)}
             />
           </View>
@@ -175,7 +178,7 @@ class CreateAccountForm extends Component<Props, State> {
               value={this.state.email}
               underlineColorAndroid='transparent'
               keyboardType='email-address'
-              onChangeText={email => this.setState({ email: formatEmail(email) })}
+              onChangeText={email => {this.setState({ email: formatEmail(email) }); onEmailTextChange(email)}}
               onBlur={(): void => onEmailTextInputBlur(this.state.email)}
             />
           </View>

--- a/packages/ui/views/authenticate/create-account/index.tsx
+++ b/packages/ui/views/authenticate/create-account/index.tsx
@@ -40,7 +40,9 @@ class CreateAccountView extends Component<Props, AccountViewState> {
   }
 
   async handleOnNickTextInputBlur(nickname: string) {
-    if(nickLengthIncorrect(nickname)) {
+    if (nickname.length == 0) {
+      this.setState({ nickDuplicationViolation: false, nickLengthViolation: false })
+    } else if(nickLengthIncorrect(nickname)) {
       this.setState({ nickLengthViolation: true })
     } else {
       const duplicateNick = await takenNick(nickname)
@@ -50,6 +52,10 @@ class CreateAccountView extends Component<Props, AccountViewState> {
         this.setState({ nickDuplicationViolation: false, nickLengthViolation: false })
       }
     }
+  }
+
+  async handleOnNickTextChange(nickname: string) {
+    this.setState({ nickDuplicationViolation: false, nickLengthViolation: false })
   }
 
   renderNickTextInputErrorText() {
@@ -65,7 +71,9 @@ class CreateAccountView extends Component<Props, AccountViewState> {
   }
 
   async handleOnEmailTextInputBlur(email: string) {
-    if (emailFormatIncorrect(email)) {
+    if (email.length == 0) {
+      this.setState({ emailDuplicationViolation: false, emailFormatViolation: false })
+    } else if (emailFormatIncorrect(email)) {
       this.setState({ emailFormatViolation: true })
     } else {
       const duplicateEmail = await takenEmail(email)
@@ -76,6 +84,10 @@ class CreateAccountView extends Component<Props, AccountViewState> {
         this.setState({ emailDuplicationViolation: false, emailFormatViolation: false })
       }
     }
+  }
+
+  async handleOnEmailTextChange(email: string) {
+    this.setState({ emailDuplicationViolation: false, emailFormatViolation: false })
   }
 
   renderEmailTextInputErrorText() {
@@ -94,8 +106,10 @@ class CreateAccountView extends Component<Props, AccountViewState> {
         <CreateAccountForm
           nickInputError={this.renderNickTextInputErrorText()}
           onNickTextInputBlur={this.handleOnNickTextInputBlur.bind(this)}
+          onNickTextChange={this.handleOnNickTextChange.bind(this)}
           emailInputError={this.renderEmailTextInputErrorText()}
           onEmailTextInputBlur={this.handleOnEmailTextInputBlur.bind(this)}
+          onEmailTextChange={this.handleOnEmailTextChange.bind(this)}
           onSubmitRecover={this.props.goToRecoverAccount}
           nickDuplicationViolation={this.state.nickDuplicationViolation}
           nickLengthViolation={this.state.nickLengthViolation}


### PR DESCRIPTION
On the create account screen, if a user entered an existing nickname or bad email address, the error messages would never disappear. This change causes those error messages to disappear as soon as the user makes a change to the text input.