### PR TITLE
Fix narrow layout (e.g. iPhone SE)

### DIFF
--- a/packages/navigators/dashboard.tsx
+++ b/packages/navigators/dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { View, Text, Platform, TouchableHighlight, Image } from 'react-native'
+import { View, Text, Platform, TouchableHighlight, Image, Dimensions } from 'react-native'
 import { TabNavigator } from 'react-navigation'
 
 import { Tab } from 'ui/components/tabs'
@@ -17,7 +17,7 @@ import { connect } from 'react-redux'
 
 import language from 'language'
 
-const { 
+const {
   accountViewLanguage,
   tabs
  } = language
@@ -65,20 +65,24 @@ class DashboardNavigatorWithHeader extends Component<Props> {
   }
 
   render() {
+    const { width } = Dimensions.get('window')
+    const logoSize = (width > 320) ? "normal" : "small"
+    const logoContainerStyle = (width > 320) ? style.dashboardLogo : style.dashboardLogoSmall
+    const tabContainer = (width > 320) ? TabStyle.tabContainer : { marginRight: 5}
 
     return (
       <View style={general.whiteFlex}>
         <AndroidStatusBar />
         <View style={style.dashboardBackground}>
           <View style={style.dashboardContainer}>
-            <View style={style.dashboardLogo}>
-              <TextLogo name='white'/>
+            <View style={logoContainerStyle}>
+              <TextLogo name='white' size={logoSize}/>
             </View>
             <View style={TabStyle.leftTriangle}/>
-            <View style={[TabStyle.tabsContainer]}>
-              <Tab onPress={() => this.props.navigation.navigate('Home')} text={tabs.home} alerts={this.props.needsReviewTransactionsCount} active={this.props.isFocusingOn('Home')} />
-              <Tab onPress={() => this.props.navigation.navigate('Friends')} text={tabs.friends} active={this.props.isFocusingOn('Friends')} />
-              <Tab onPress={() => this.props.navigation.navigate('Activity')} text={tabs.activity} active={this.props.isFocusingOn('Activity')} />
+            <View style={TabStyle.tabsContainer}>
+              <Tab style={tabContainer} onPress={() => this.props.navigation.navigate('Home')} text={tabs.home} alerts={this.props.needsReviewTransactionsCount} active={this.props.isFocusingOn('Home')} />
+              <Tab style={tabContainer} onPress={() => this.props.navigation.navigate('Friends')} text={tabs.friends} active={this.props.isFocusingOn('Friends')} />
+              <Tab style={tabContainer} onPress={() => this.props.navigation.navigate('Activity')} text={tabs.activity} active={this.props.isFocusingOn('Activity')} />
             </View>
           </View>
         </View>
@@ -89,8 +93,8 @@ class DashboardNavigatorWithHeader extends Component<Props> {
           </TouchableHighlight>
         </View>
         <View style={style.settingsTriangleRight}/>
-        
-        
+
+
         <DashboardNavigator navigation={this.props.navigation}/>
       </View>
     )

--- a/packages/navigators/dashboard.tsx
+++ b/packages/navigators/dashboard.tsx
@@ -65,10 +65,11 @@ class DashboardNavigatorWithHeader extends Component<Props> {
   }
 
   render() {
+    const kSmallScreenThreshold = 320 // e.g. iPhone SE
     const { width } = Dimensions.get('window')
-    const logoSize = (width > 320) ? "normal" : "small"
-    const logoContainerStyle = (width > 320) ? style.dashboardLogo : style.dashboardLogoSmall
-    const tabContainer = (width > 320) ? TabStyle.tabContainer : { marginRight: 5}
+    const logoSize = (width > kSmallScreenThreshold) ? "normal" : "small"
+    const logoContainerStyle = (width > kSmallScreenThreshold) ? style.dashboardLogo : style.dashboardLogoSmall
+    const tabContainer = (width > kSmallScreenThreshold) ? TabStyle.tabContainer : { marginRight: 5}
 
     return (
       <View style={general.whiteFlex}>

--- a/packages/theme/account.ts
+++ b/packages/theme/account.ts
@@ -40,6 +40,12 @@ export default StyleSheet.create({
     marginLeft: 15,
     width: 90
   },
+  dashboardLogoSmall: {
+    marginTop: 40,
+    marginBottom: 20,
+    marginLeft: 10,
+    width: 80
+  },
   dashboardTextContainer: {
     alignItems: 'center',
     justifyContent: 'center'

--- a/packages/theme/friend.ts
+++ b/packages/theme/friend.ts
@@ -65,7 +65,8 @@ export default StyleSheet.create({
   },
   settleImage: {
     width: 100,
-    height: 100
+    height: 100,
+    borderRadius: 50
   },
   transactions: {
     flex: 1,

--- a/packages/theme/tabs.ts
+++ b/packages/theme/tabs.ts
@@ -33,7 +33,7 @@ export default StyleSheet.create({
     alignItems: 'center'
   },
   tabActive: {
-    
+
   },
   text: {
     color: charcoal,

--- a/packages/ui/components/dashboard-shell/index.tsx
+++ b/packages/ui/components/dashboard-shell/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { View, Text, Platform, Image, TouchableHighlight } from 'react-native'
+import { View, Text, Platform, Image, TouchableHighlight, Dimensions } from 'react-native'
 import { TabNavigator } from 'react-navigation'
 
 import { Tab } from 'ui/components/tabs'
@@ -15,7 +15,7 @@ import { logoutAccount } from 'actions'
 import { connect } from 'react-redux'
 
 import language from 'language'
-const { 
+const {
   accountViewLanguage,
   tabs
  } = language
@@ -52,13 +52,16 @@ const DashboardNavigator = TabNavigator(RouteConfig, TabNavigatorConfig)
 class DashboardShell extends Component<Props> {
   render() {
     const { text } = this.props
+    const { width } = Dimensions.get('window')
+    const logoSize = (width > 320) ? "normal" : "small"
+    const logoContainerStyle = (width > 320) ? style.dashboardLogo : style.dashboardLogoSmall
 
     return (
       <View style={general.whiteFlex}>
         <AndroidStatusBar />
         <View style={style.dashboardContainer}>
-          <View style={style.dashboardLogo}>
-            <TextLogo name='white'/>
+          <View style={logoContainerStyle}>
+            <TextLogo name='white' size={logoSize}/>
           </View>
           <View style={TabStyle.leftTriangle}/>
           <View style={[TabStyle.tabsContainer, style.dashboardTextContainer]}>

--- a/packages/ui/components/dashboard-shell/index.tsx
+++ b/packages/ui/components/dashboard-shell/index.tsx
@@ -51,10 +51,11 @@ const DashboardNavigator = TabNavigator(RouteConfig, TabNavigatorConfig)
 
 class DashboardShell extends Component<Props> {
   render() {
+    const kSmallScreenThreshold = 320 // e.g. iPhone SE
     const { text } = this.props
     const { width } = Dimensions.get('window')
-    const logoSize = (width > 320) ? "normal" : "small"
-    const logoContainerStyle = (width > 320) ? style.dashboardLogo : style.dashboardLogoSmall
+    const logoSize = (width > kSmallScreenThreshold) ? "normal" : "small"
+    const logoContainerStyle = (width > kSmallScreenThreshold) ? style.dashboardLogo : style.dashboardLogoSmall
 
     return (
       <View style={general.whiteFlex}>

--- a/packages/ui/components/images/text-logo/index.tsx
+++ b/packages/ui/components/images/text-logo/index.tsx
@@ -12,11 +12,20 @@ const getImageFromName = {
   'white': require('images/text-logo-white.png')
 }
 
-export default ({name}) => (
+export default ({name, size = ""}) => (
   <View>
     <Image
-      style={name === 'white' ? {height: 30, width: 90} : {height: 40, width: 120}}
+      style={getStyle(size, name)}
       source={getImageFromName[name]}
     />
   </View>
 )
+
+function getStyle(size, name) {
+  switch (size) {
+    case 'small':
+      return {height: 25, width: 75}
+    default:
+      return (name == "white") ? {height: 30, width: 90} : {height: 40, width: 120}
+  }
+}

--- a/packages/ui/components/spinning-picker/index.tsx
+++ b/packages/ui/components/spinning-picker/index.tsx
@@ -7,7 +7,7 @@ import style from 'theme/account'
 import general from 'theme/general'
 
 import language from 'language'
-const { debtManagement } = language
+const { debtManagement, confirmation } = language
 
 interface Props {
   onPickerDone: (selectedItem: any) => void
@@ -36,7 +36,7 @@ class SpinningPicker extends Component<Props, State> {
         <View style={this.props.containerStyle}>
           <View style={[general.flexRow, general.alignCenter, general.standardHMargin]}>
             <Text style={[general.stretch, style.title]}>{this.props.label}</Text>
-            <Button small onPress={() => this.props.onPickerDone(this.state.selectedItem)} text="Done" />
+            <Button round medium narrow onPress={() => this.props.onPickerDone(this.state.selectedItem)} text={confirmation.done} />
           </View>
           <Picker
             selectedValue={this.state.selectedItem}

--- a/packages/ui/components/tabs/index.tsx
+++ b/packages/ui/components/tabs/index.tsx
@@ -36,7 +36,7 @@ export class Tab extends Component<Props> {
 
     return (
       <TouchableHighlight
-        style={style.tabContainer}
+        style={this.props.style}
         underlayColor={clear}
         activeOpacity={0.5}
         onPress={onPress}

--- a/packages/ui/dialogs/add-debt/index.tsx
+++ b/packages/ui/dialogs/add-debt/index.tsx
@@ -113,7 +113,7 @@ class AddDebt extends Component<Props, State> {
     const selectFriend = () => this.setState({ shouldSelectFriend: true })
 
     if (!friend) {
-      return <Button round large onPress={selectFriend} text={debtManagement.selectFriend} />
+      return <Button round medium narrow onPress={selectFriend} text={debtManagement.selectFriend} />
     }
 
     return (<TouchableHighlight onPress={selectFriend}>
@@ -206,7 +206,7 @@ class AddDebt extends Component<Props, State> {
       <View style={[general.centeredColumn, {marginBottom: 20}]}>
         <Text style={[style.header, {marginBottom: 20}]}>{debtManagement[direction]}</Text>
         <View style={[general.flex, general.flexRow]} >
-          <View style={[general.centeredColumn, {minWidth: 150}]}>
+          <View style={[general.centeredColumn]}>
             <Text style={formStyle.title}>{debtManagement.fields.selectFriend}</Text>
             <View style={style.newTransactionRow}>
               { this.renderSelectedFriend() }
@@ -227,12 +227,12 @@ class AddDebt extends Component<Props, State> {
               />
             </View>
           </View>
-          <View style={general.centeredColumn}>
+          <View style={[general.centeredColumn]}>
             <Text style={formStyle.title}></Text>
             <View style={style.newTransactionRow}>
               <Button small narrow black onPress={() => this.setState({shouldPickCurrency: true})} text={currency} />
             </View>
-            
+
           </View>
         </View>
         <View style={formStyle.memoBorder} >
@@ -263,6 +263,6 @@ class AddDebt extends Component<Props, State> {
   }
 }
 
-export default connect((state) => ({ state: getStore(state)(), pendingTransactions: pendingTransactions(state), 
+export default connect((state) => ({ state: getStore(state)(), pendingTransactions: pendingTransactions(state),
   recentTransactions: recentTransactions(state), allCurrencies: getAllUcacCurrencies(state),
    hasPendingTransaction: hasPendingTransaction(state) }), { addDebt, getFriends, hasPendingMessage })(AddDebt)

--- a/packages/ui/views/account/home/index.tsx
+++ b/packages/ui/views/account/home/index.tsx
@@ -20,7 +20,7 @@ import PendingTransaction from 'lndr/pending-transaction'
 
 import { isFocusingOn } from 'reducers/nav'
 import { getStore, getUser, getNeedsReviewCount } from 'reducers/app'
-import { getAccountInformation, displayError, getPendingTransactions, getPendingSettlements, 
+import { getAccountInformation, displayError, getPendingTransactions, getPendingSettlements,
   getFriendRequests, getBalances, registerChannelID } from 'actions'
 import { connect } from 'react-redux'
 import { UrbanAirship } from 'urbanairship-react-native'
@@ -143,7 +143,7 @@ class HomeView extends Component<Props, State> {
       <Text style={[formStyle.titleLarge, formStyle.center, formStyle.spaceBottom, formStyle.spaceTop]}>{needsReview}</Text>
       <PendingView navigation={this.props.navigation} homeScreen />
     </View>
-    : <View style={{height: 100}} />
+    : <View style={{height: 20}} />
   }
 
   renderBalanceInformation() {
@@ -224,6 +224,6 @@ class HomeView extends Component<Props, State> {
   }
 }
 
-export default connect((state) => ({ state: getStore(state)(), user: getUser(state)(), isFocused: isFocusingOn(state)('Home'), 
+export default connect((state) => ({ state: getStore(state)(), user: getUser(state)(), isFocused: isFocusingOn(state)('Home'),
 needsReviewCount: getNeedsReviewCount(state) }), { getAccountInformation, displayError, getPendingTransactions, getPendingSettlements,
 getFriendRequests, getBalances, registerChannelID })(HomeView)


### PR DESCRIPTION
A series of commits to handle narrow screen layouts like iPhone SE, including:
LNDR-22: currency selector cut-off
LNDR-21: tab bar cut-off
Also includes:
LNDR-25: See All Activity too far down
LNDR-26: rounding avatar or Settle Up