### PR TITLE
Fixed PIN validation for changing PIN

### DIFF
--- a/packages/actions/index.ts
+++ b/packages/actions/index.ts
@@ -864,6 +864,12 @@ export const validatePin = async (confirmPassword: string) => {
   return bcrypt.compareSync(confirmPassword, hashedPassword)
 }
 
+export const failedValidatePin = () => {
+  return async (dispatch) => {
+    dispatch(displayError(accountManagement.pin.failedHashComparison))
+  }
+}
+
 export const updateLockTimeout = (timeout: number) => {
   return async (dispatch, getState) => {
     try {

--- a/packages/ui/dialogs/my-account/index.tsx
+++ b/packages/ui/dialogs/my-account/index.tsx
@@ -88,7 +88,7 @@ class MyAccount extends Component<Props, State> {
     this.state = {
       ...defaultUpdateAccountData(),
       lockTimeout: '',
-      hiddenPanels: [true, true, true, true, true, true, true, true, true, true, true, true, true],
+      hiddenPanels: accountManagement.panelHeaders.map( () => true),
       step: 1,
       photos: [],
       authenticated: false,

--- a/packages/ui/dialogs/my-account/index.tsx
+++ b/packages/ui/dialogs/my-account/index.tsx
@@ -130,14 +130,13 @@ class MyAccount extends Component<Props, State> {
 
   async componentDidUpdate() {
     const { password, confirmPassword, step, scrollY } = this.state
-    const { failedValidatePin } = this.props
 
     if (step === 4 && confirmPassword.length === 4 ) {
       const authenticated = await loadingContext.wrap(validatePin(confirmPassword))
 
       const self = this as any
       if(!authenticated) {
-        failedValidatePin()
+        this.props.failedValidatePin()
       }
       setTimeout( () => self.refs.scrollContent.scrollTo({ x: 0, y: scrollY, animated: true }), 200)
       this.setState({ step: 1, confirmPassword: '', authenticated })

--- a/packages/ui/dialogs/my-account/index.tsx
+++ b/packages/ui/dialogs/my-account/index.tsx
@@ -20,7 +20,7 @@ import { currencySymbols, transferLimits  } from 'lndr/currencies'
 
 import { getAccountInformation, updateNickname, updateEmail, logoutAccount, toggleNotifications,
   setEthBalance, updateLockTimeout, updatePin, getProfilePic, setProfilePic, takenNick, takenEmail,
-  copyToClipboard, validatePin, setPrimaryCurrency } from 'actions'
+  copyToClipboard, validatePin, setPrimaryCurrency, failedValidatePin } from 'actions'
 import { getUser, getStore, getAllUcacCurrencies, getPrimaryCurrency } from 'reducers/app'
 import { getResetAction } from 'reducers/nav'
 import { connect } from 'react-redux'
@@ -62,6 +62,7 @@ interface Props {
   setProfilePic: (imageURI: string, imageData: string) => any
   copyToClipboard: (text: string) => any
   setPrimaryCurrency: (value: string) => any
+  failedValidatePin: () => void
 }
 
 interface State {
@@ -87,7 +88,7 @@ class MyAccount extends Component<Props, State> {
     this.state = {
       ...defaultUpdateAccountData(),
       lockTimeout: '',
-      hiddenPanels: [true, true, true, true, true, true, true, true, true, true, true],
+      hiddenPanels: [true, true, true, true, true, true, true, true, true, true, true, true, true],
       step: 1,
       photos: [],
       authenticated: false,
@@ -129,13 +130,17 @@ class MyAccount extends Component<Props, State> {
 
   async componentDidUpdate() {
     const { password, confirmPassword, step, scrollY } = this.state
+    const { failedValidatePin } = this.props
 
     if (step === 4 && confirmPassword.length === 4 ) {
-      const authenticated = loadingContext.wrap(validatePin(confirmPassword))
-      this.setState({ step: 1, confirmPassword: '', authenticated })
+      const authenticated = await loadingContext.wrap(validatePin(confirmPassword))
 
       const self = this as any
-      setTimeout(function() {self.refs.scrollContent.scrollTo({ x: 0, y: scrollY + 200, animated: true })}, 200)
+      if(!authenticated) {
+        failedValidatePin()
+      }
+      setTimeout( () => self.refs.scrollContent.scrollTo({ x: 0, y: scrollY, animated: true }), 200)
+      this.setState({ step: 1, confirmPassword: '', authenticated })
     } else if (step === 3 && password.length === 4 && confirmPassword.length === 4) {
       this.setState({ step: 5 })
     } else if (password.length === 4 && step === 2) {
@@ -449,4 +454,4 @@ class MyAccount extends Component<Props, State> {
 export default connect((state) => ({ user: getUser(state)(), state: getStore(state)(), allCurrencies: getAllUcacCurrencies(state),
   primaryCurrency: getPrimaryCurrency(state)}), { updateEmail, updateNickname,
   getAccountInformation, logoutAccount, toggleNotifications, setEthBalance, updateLockTimeout, updatePin,
-  getProfilePic, setProfilePic, copyToClipboard, setPrimaryCurrency })(MyAccount)
+  getProfilePic, setProfilePic, copyToClipboard, setPrimaryCurrency, failedValidatePin })(MyAccount)

--- a/packages/ui/forms/create-account/index.tsx
+++ b/packages/ui/forms/create-account/index.tsx
@@ -151,7 +151,7 @@ class CreateAccountForm extends Component<Props, State> {
       </View>
     } else {
       const vertOffset = (Platform.OS === 'android') ? -300 : 0;
-      return (<ScrollView keyboardShouldPersistTaps="always">
+      return (<ScrollView keyboardShouldPersistTaps="never">
         <View style={style.form}>
           <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'position' : 'padding'} keyboardVerticalOffset={vertOffset} >
             <ThemeImage name='logo' size={0.4} />

--- a/packages/ui/forms/recover-account/index.tsx
+++ b/packages/ui/forms/recover-account/index.tsx
@@ -29,7 +29,7 @@ import style from 'theme/form'
 const loadingContext = new LoadingContext()
 
 interface Props {
-  onSubmitRecoverUser: (formData: RecoverAccountData) => void
+  onSubmitRecoverUser: (formData: RecoverAccountData) => any
   onCancel: () => void
   user: User
 }
@@ -135,6 +135,7 @@ class RecoverAccountForm extends Component<Props, State> {
   }
 
   setPIN() {
+    console.log('WHAT ', this.state.mnemonicLengthError)
     if (this.state.mnemonicLengthError) {
       return
     }
@@ -162,7 +163,7 @@ class RecoverAccountForm extends Component<Props, State> {
       </View>
     } else {
       const vertOffset = (Platform.OS === 'android') ? -300 : 0;
-      return <ScrollView keyboardShouldPersistTaps="always">
+      return <ScrollView keyboardShouldPersistTaps="never">
         <View style={style.form}>
           <ThemeImage name='logo' size={0.4} />
           <Text style={[style.text, style.spaceBottom]}>{recoverExistingAccount}</Text>

--- a/packages/ui/views/authenticate/index.tsx
+++ b/packages/ui/views/authenticate/index.tsx
@@ -7,7 +7,6 @@ import FadeInView from 'ui/components/fade-in-view'
 import LoginView from './login'
 import CreateAccountView from './create-account'
 import RecoverAccountView from './recover-account'
-import RemoveAccountView from './remove-account'
 import ConfirmAccountView from './confirm-account'
 
 import general from 'theme/general'
@@ -54,8 +53,6 @@ class AuthenticateView extends Component<Props> {
 
     if (shouldDisplayMnemonic) {
       return <ConfirmAccountView />
-    } else if (shouldRemoveAccount) {
-      return <RemoveAccountView />
     } else if (hasStoredUser) {
       return <LoginView />
     } else if (shouldRecoverAccount) {


### PR DESCRIPTION
 1. Problem: PIN validation was not set up correctly on the MyAccount page. The user could previously set a new PIN after entering an incorrect PIN.  https://blockmason.atlassian.net/secure/RapidBoard.jspa?rapidView=9&modal=detail&selectedIssue=ENG-51
 2. Solution: Add an 'await' to the function that validates the PIN to wait for the boolean result, then display a message on PIN failure
 3. No concerns
 4. No blockers