### PR TITLE
Allow user to remove friend even if they have transactions

### DIFF
--- a/packages/lndr/profile-pic/index.ts
+++ b/packages/lndr/profile-pic/index.ts
@@ -40,7 +40,7 @@ export default {
       return `data:image/jpg;base64,${base64Data}`
     })
     .catch( err => {
-      console.log('Profile Pic Error: ', err)
+      console.log('Error getting profile pic: ', err)
     })
   },
 

--- a/packages/navigators/index.tsx
+++ b/packages/navigators/index.tsx
@@ -111,7 +111,7 @@ class AppWithNavigationState extends React.Component<Props> {
 
   onBackPress = () => {
     const { nav, navigation } = this.props;
-    if(nav.routes && nav.routes[1] && nav.routes[1].routeName === 'FriendDetail') {
+    if(nav.routes instanceof Array && nav.routes[1] && nav.routes[1].routeName === 'FriendDetail') {
       return true
     } else if (nav.index === 0 && nav.routes[0].index === 0) {
       BackHandler.exitApp()

--- a/packages/navigators/index.tsx
+++ b/packages/navigators/index.tsx
@@ -111,7 +111,9 @@ class AppWithNavigationState extends React.Component<Props> {
 
   onBackPress = () => {
     const { nav, navigation } = this.props;
-    if (nav.index === 0 && nav.routes[0].index === 0) {
+    if(nav.routes && nav.routes[1] && nav.routes[1].routeName === 'FriendDetail') {
+      return true
+    } else if (nav.index === 0 && nav.routes[0].index === 0) {
       BackHandler.exitApp()
       return false
     }

--- a/packages/theme/account.ts
+++ b/packages/theme/account.ts
@@ -391,6 +391,20 @@ export default StyleSheet.create({
     width: '100%',
     color: black,
     textAlign: 'center'
+  },
+  removeFriendConfirmation: {
+    width: '40%',
+    marginHorizontal: 10
+  },
+  removeFriendMessage: {
+    ...large,
+    ...bold,
+    marginBottom: 3,
+    color: black,
+    textAlign: 'center',
+    marginVertical: 40,
+    paddingBottom: 20,
+    marginHorizontal: 20
   }
 
 } as any)

--- a/packages/ui/components/balance-section/index.tsx
+++ b/packages/ui/components/balance-section/index.tsx
@@ -1,8 +1,6 @@
-import { Text, TouchableHighlight, View, Image } from 'react-native'
+import { Text, View } from 'react-native'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-
-import Friend from 'lndr/friend'
 
 import BalanceRow from 'ui/components/balance-row'
 
@@ -15,7 +13,7 @@ import language from 'language'
 const { debtManagement } = language
 
 interface Props {
-  friend: Friend
+  friend: any
   calculateUcacBalances: (friendAddr: string) => object
 }
 

--- a/packages/ui/components/balance-section/index.tsx
+++ b/packages/ui/components/balance-section/index.tsx
@@ -2,6 +2,8 @@ import { Text, View } from 'react-native'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 
+import Friend from 'lndr/friend'
+
 import BalanceRow from 'ui/components/balance-row'
 
 import style from 'theme/account'
@@ -13,7 +15,7 @@ import language from 'language'
 const { debtManagement } = language
 
 interface Props {
-  friend: any
+  friend: Friend
   calculateUcacBalances: (friendAddr: string) => object
 }
 

--- a/packages/ui/components/friend-row/index.tsx
+++ b/packages/ui/components/friend-row/index.tsx
@@ -22,7 +22,7 @@ const { debtManagement } = language
 
 interface Props {
   onPress?: () => void
-  friend: any
+  friend: Friend
   friendScreen?: boolean
   recentTransactions?: any
   navigation: any

--- a/packages/ui/dialogs/friend-detail/index.tsx
+++ b/packages/ui/dialogs/friend-detail/index.tsx
@@ -100,7 +100,7 @@ class RemoveFriend extends Component<Props, State> {
       removeFriendText,
       removeFriendConfirmationQuestion,
       [
-        {text: cancel.toUpperCase(), onPress: () => null},
+        {text: cancel.toUpperCase(), onPress: () => null, style: 'destructive'},
         {text: confirmAccount.toUpperCase(), onPress: this.removeFriend},
       ],
       { cancelable: true }

--- a/packages/ui/dialogs/friend-detail/index.tsx
+++ b/packages/ui/dialogs/friend-detail/index.tsx
@@ -66,23 +66,25 @@ class RemoveFriend extends Component<Props, State> {
       balance: new Balance({ relativeToNickname: "", relativeTo: "", amount: 0 }),
       removeFriend: false
     }
+
+    this.removeFriend = this.removeFriend.bind(this)
+    this.goBack = this.goBack.bind(this)
+    this.goSettleUp = this.goSettleUp.bind(this)
+    this.confirmRemoveFriend = this.confirmRemoveFriend.bind(this)
+    this.unconfirmRemoveFriend = this.unconfirmRemoveFriend.bind(this)
   }
 
   async componentWillMount() {
     const friend = this.props.navigation ? this.props.navigation.state.params.friend : {}
-    let pic
 
-    try {
-      if (friend.address !== undefined) {
-        pic = await profilePic.get(friend.address)
-      }
-    } catch (e) {}
-    if (pic) {
+    if (friend.address !== undefined) {
+      const pic = await profilePic.get(friend.address)
       this.setState({ pic })
     }
   }
 
-  async removeFriend(friend: Friend) {
+  async removeFriend() {
+    const friend = this.props.navigation ? this.props.navigation.state.params.friend : {}
     await loadingContext.wrap(this.props.removeFriend(friend))
 
     this.props.navigation.goBack()
@@ -121,6 +123,23 @@ class RemoveFriend extends Component<Props, State> {
     return this.getRecentTotal() < 0 ? accountStyle.redAmount : accountStyle.greenAmount
   }
 
+  goBack() {
+    this.props.navigation.goBack(null)
+  }
+
+  goSettleUp() {
+    const friend = this.props.navigation ? this.props.navigation.state.params.friend : {}
+    this.props.navigation.navigate('SettleUp', { friend })
+  }
+
+  confirmRemoveFriend() {
+    this.setState({ removeFriend: true })
+  }
+
+  unconfirmRemoveFriend() {
+    this.setState({ removeFriend: false })
+  }
+
   render() {
     const friend = this.props.navigation ? this.props.navigation.state.params.friend : {}
     const { navigation, primaryCurrency } = this.props
@@ -132,12 +151,12 @@ class RemoveFriend extends Component<Props, State> {
         <View style={general.view}>
           <DashboardShell text={friendShell} navigation={this.props.navigation} />
           <Loading context={loadingContext} />
-          <Button close onPress={() => this.setState({ removeFriend: false })} />
+          <Button close onPress={this.unconfirmRemoveFriend} />
         </View>
         <Text style={accountStyle.removeFriendMessage}>{removeFriendConfirmationQuestion}</Text>
         <View style={[general.flexRow, {justifyContent: 'center'}]}>
-          <Button round fat danger onPress={() => this.setState({ removeFriend: false })} text={cancel.toUpperCase()} containerStyle={accountStyle.removeFriendConfirmation}/>
-          <Button round fat onPress={() => this.removeFriend(friend)} text={confirmAccount.toUpperCase()} containerStyle={accountStyle.removeFriendConfirmation}/>
+          <Button round fat danger onPress={this.unconfirmRemoveFriend} text={cancel.toUpperCase()} containerStyle={accountStyle.removeFriendConfirmation}/>
+          <Button round fat onPress={this.removeFriend} text={confirmAccount.toUpperCase()} containerStyle={accountStyle.removeFriendConfirmation}/>
         </View>
       </View>
     }
@@ -146,13 +165,13 @@ class RemoveFriend extends Component<Props, State> {
       <View style={general.view}>
         <DashboardShell text={friendShell} navigation={this.props.navigation} />
         <Loading context={loadingContext} />
-        <Button close onPress={() => this.props.navigation.goBack(null)} />
+        <Button close onPress={this.goBack} />
       </View>
       <ScrollView style={general.view}  keyboardShouldPersistTaps="always">
         <View style={general.centeredColumn}>
           <Image source={imageSource} style={pendingStyle.image}/>
           <Text style={pendingStyle.title}>{`  @${friend.nickname}  `}</Text>
-          <Button round danger onPress={() => this.setState({ removeFriend: true })} text={removeFriendText} containerStyle={style.spaceBottom} />
+          <Button round danger onPress={this.confirmRemoveFriend} text={removeFriendText} containerStyle={style.spaceBottom} />
           <Text style={pendingStyle.subTitle}>{`${recentTransactionsLanguage.consolidatedBalance}:`}</Text>
           <View style={pendingStyle.balanceRow}>
             <Text style={pendingStyle.balanceInfo}>{currencySymbols(primaryCurrency)}</Text>
@@ -161,7 +180,7 @@ class RemoveFriend extends Component<Props, State> {
           <View style={[general.centeredColumn, {marginBottom: 10}]}>
             <BalanceSection friend={friend} />
           </View>
-          {this.getRecentTotal() === 0 ? null : <Button round large fat wide onPress={() => this.props.navigation.navigate('SettleUp', { friend: friend })} text={debtManagement.settleUp} containerStyle={style.spaceBottom} />}
+          {this.getRecentTotal() === 0 ? null : <Button round large fat wide onPress={this.goSettleUp} text={debtManagement.settleUp} containerStyle={style.spaceBottom} />}
           <View style={style.fullWidth}>
             <Text style={accountStyle.transactionHeader}>{pendingTransactionsLanguage.title}</Text>
             <PendingView friend={friend} navigation={navigation} />


### PR DESCRIPTION
 1. Problem: Users cannot remove friends with whom they have transactions. https://blockmason.atlassian.net/secure/RapidBoard.jspa?rapidView=9&modal=detail&selectedIssue=ENG-105
 2. Solution: Show the user the 'Remove Friend' button on the FriendDetail screen when the users have transactions, and then show a short confirmation screen. The main added complexity is a removal confirmation screen and a separate Android BackHandler for that screen since it relies on setState rather than navigation
 3. No trade-offs or concerns
 4. No blockers