### PR TITLE
Fixed issue with nickname not updating after change

### DIFF
--- a/packages/actions/index.ts
+++ b/packages/actions/index.ts
@@ -125,8 +125,9 @@ export const getAccountInformation = () => {
     const user = getUser(getState())()
 
     try {
-      user.nickname = await creditProtocol.getNickname(user.address)
-      user.email = await creditProtocol.getEmail(user.address)
+      const [ nickname, email ] = await Promise.all([creditProtocol.getNickname(user.address), creditProtocol.getEmail(user.address)])
+      user.nickname = nickname
+      user.email = email
     } catch (e) { console.log('ERROR GETTING EMAIL OR NICKNAME: ', e) }
 
     await userStorage.set(user)

--- a/packages/actions/index.ts
+++ b/packages/actions/index.ts
@@ -124,15 +124,10 @@ export const getAccountInformation = () => {
   return async (dispatch, getState) => {
     const user = getUser(getState())()
 
-    if (user.nickname.length === 0) {
-      try {
-        user.nickname = await creditProtocol.getNickname(user.address)
-      } catch (e) { console.log('ERROR GETTING NICKNAME: ', e) }
-    } else if(user.email.length === 0) {
-      try {
-        user.email = await creditProtocol.getEmail(user.address)
-      } catch (e) { console.log('ERROR GETTING EMAIL: ', e) }
-    }
+    try {
+      user.nickname = await creditProtocol.getNickname(user.address)
+      user.email = await creditProtocol.getEmail(user.address)
+    } catch (e) { console.log('ERROR GETTING EMAIL OR NICKNAME: ', e) }
 
     await userStorage.set(user)
     dispatch(setState({ user }))

--- a/packages/credit-protocol/index.ts
+++ b/packages/credit-protocol/index.ts
@@ -84,6 +84,8 @@ export default class CreditProtocol {
     const hash = bufferToHex(ethUtil.sha3(hashBuffer))
     const signature = this.serverSign(hash, privateKeyBuffer)
 
+    delete this.tempStorage.nicknames[addr]
+
     return this.client.post('/nick', {
       addr,
       nick,
@@ -99,6 +101,8 @@ export default class CreditProtocol {
     ])
     const hash = bufferToHex(ethUtil.sha3(hashBuffer))
     const signature = this.serverSign(hash, privateKeyBuffer)
+
+    delete this.tempStorage.emails[addr]
 
     return this.client.post('/email', {
       addr,
@@ -152,20 +156,20 @@ export default class CreditProtocol {
     return this.client.get(`/counterparties/${user}`)
   }
 
-  getNickname(user: string) {
-    const nickname = this.tempStorage.nicknames[user]
+  getNickname(addr: string) {
+    const nickname = this.tempStorage.nicknames[addr]
     if (nickname) {
       return nickname
     }
-    return this.tempStorage.nicknames[user] = this.client.get(`/nick/${user}`)
+    return this.tempStorage.nicknames[addr] = this.client.get(`/nick/${addr}`)
   }
 
-  getEmail(user: string) {
-    const email = this.tempStorage.emails[user]
+  getEmail(addr: string) {
+    const email = this.tempStorage.emails[addr]
     if (email) {
       return email
     }
-    return this.tempStorage.emails[user] = this.client.get(`/email/${user}`)
+    return this.tempStorage.emails[addr] = this.client.get(`/email/${addr}`)
   }
 
   getPayPal(user: string) {

--- a/packages/ui/dialogs/my-account/index.tsx
+++ b/packages/ui/dialogs/my-account/index.tsx
@@ -15,9 +15,9 @@ import InputImage from 'ui/components/images/input-image'
 import SpinningPicker from 'ui/components/spinning-picker'
 
 import { formatNick, formatLockTimeout, formatEmail, emailFormatIncorrect } from 'lndr/format'
-import { defaultUpdateAccountData, UpdateAccountData, UserData } from 'lndr/user'
+import { UpdateAccountData, UserData } from 'lndr/user'
 
-import { getAccountInformation, updateNickname, updateEmail, logoutAccount, toggleNotifications,
+import { updateNickname, updateEmail, logoutAccount, toggleNotifications, getAccountInformation,
   setEthBalance, updateLockTimeout, updatePin, getProfilePic, setProfilePic, takenNick, takenEmail,
   copyToClipboard, validatePin, setPrimaryCurrency, failedValidatePin } from 'actions'
 import { getUser, getStore, getAllUcacCurrencies, getPrimaryCurrency } from 'reducers/app'
@@ -90,7 +90,10 @@ class MyAccount extends Component<Props, State> {
   constructor(props) {
     super(props)
     this.state = {
-      ...defaultUpdateAccountData(),
+      nickname: props.user.nickname,
+      email: props.user.email,
+      password: '',
+      confirmPassword: '',
       lockTimeout: '',
       hiddenPanels: accountManagement.panelHeaders.map( () => true),
       step: 1,
@@ -99,7 +102,7 @@ class MyAccount extends Component<Props, State> {
       currency: props.primaryCurrency,
       scrollY: 0,
       shouldPickCurrency: false,
-      payPalEmail: null,
+      payPalEmail: null
     }
   }
 
@@ -107,22 +110,13 @@ class MyAccount extends Component<Props, State> {
     const { address } = this.props.user
     this.props.setEthBalance()
     this.props.getProfilePic(address)
+    this.props.getAccountInformation()
 
     // init PayPal and check if user is connected
     await NativeModules.PayPalManager.initPayPal()
     if (this.state.payPalEmail == null) {
       const payPalEmail = await palsClient.getPayPalAccount(this.props.user)
       this.setState({payPalEmail: payPalEmail})
-    }
-  }
-
-  async componentDidMount() {
-    unmounting = false
-    const accountInfo = await loadingContext.wrap(
-      this.props.getAccountInformation()
-    )
-    if(!unmounting) {
-      this.setState(accountInfo)
     }
   }
 


### PR DESCRIPTION
 1. Problem: After updating the user's nickname (and email) and then navigating away from the MyAccount screen and back, the nickname would not be updated (although it was on the server). https://blockmason.atlassian.net/secure/RapidBoard.jspa?rapidView=9&projectKey=ENG&modal=detail&selectedIssue=ENG-97
 2. Solution: Modify the credit-protocol file to clear the in-memory cache of http calls. Update the updateNickname and updateEmail functions to modify the userStorage and the user object in the store.
 3. No concerns
 4. No blockers