### PR TITLE
Fixed tx cost display for ETH and BCPT transfer

### DIFF
--- a/__tests__/credit-protocol.ts
+++ b/__tests__/credit-protocol.ts
@@ -29,6 +29,6 @@ jest.mock('react-native-fetch-blob', () => {
 describe('Initialization', () => {
   it('initializes successfully', () => {
     const creditProtocol = new CreditProtocol('https://api.lndr.blockmason.io')
-    expect(creditProtocol.tempStorage.nicknames).toEqual({})
+    expect(creditProtocol.tempStorage.registerId).toEqual({})
   })
 })

--- a/__tests__/lndr/format.ts
+++ b/__tests__/lndr/format.ts
@@ -57,5 +57,6 @@ describe('formatEthRemaining', () => {
 describe('cleanFiatAmount', () => {
   it('should return an amount in number format', () => {
     expect(cleanFiatAmount('CA$1.21')).toBe(1.21)
+    expect(cleanFiatAmount('CA$.')).toBe(0)
   })
 })

--- a/__tests__/lndr/format.ts
+++ b/__tests__/lndr/format.ts
@@ -2,7 +2,8 @@ import 'react-native'
 
 // Note: test renderer must be required after react-native.
 
-import { commas, amountFormat, formatEthToFiat, formatCommaDecimal, formatSettlementAmount, formatMemo, formatEthRemaining } from 'lndr/format'
+import { commas, amountFormat, formatEthToFiat, formatCommaDecimal, formatSettlementAmount, formatMemo, formatEthRemaining,
+  cleanFiatAmount } from 'lndr/format'
 import { getEthExchange } from 'reducers/app';
 
 describe('commas', () => {
@@ -14,10 +15,10 @@ describe('commas', () => {
 
 describe('amountFormat', () => {
   it('Formats an amount correctly', () => {
-    expect(amountFormat('1000', 'USD')).toBe('US$1,000')
-    expect(amountFormat('1000.10', 'INR')).toBe('₹1,000.10')
-    expect(amountFormat('1,000.10', 'THB')).toBe('฿1,000.10')
-    expect(amountFormat('1,0100.10', 'TRY')).toBe('₺10,100.10')
+    expect(amountFormat('1000', 'USD', false)).toBe('US$1,000')
+    expect(amountFormat('1000.1', 'INR', false)).toBe('₹1,000.1')
+    expect(amountFormat('1,000.1', 'THB', true)).toBe('฿1,000.10')
+    expect(amountFormat('1,0100.10', 'TRY', false)).toBe('₺10,100.10')
   })
 })
 
@@ -29,10 +30,10 @@ describe('formatEthToFiat', () => {
 
 describe('formatSettlementAmount', () => {
   it('Formats an ETH amount correctly', () => {
-    expect(formatSettlementAmount('2', 110, 'USD')).toBe('US$1.10')
-    expect(formatSettlementAmount('1', 210, 'USD')).toBe('US$2.10')
-    expect(formatSettlementAmount('410', 410, 'USD')).toBe('US$4.10')
-    expect(formatSettlementAmount('3.11', 311, 'USD')).toBe('US$3.11')
+    expect(formatSettlementAmount('110', 'USD')).toBe('US$1.10')
+    expect(formatSettlementAmount('210', 'USD')).toBe('US$2.10')
+    expect(formatSettlementAmount('410', 'USD')).toBe('US$4.10')
+    expect(formatSettlementAmount('311', 'USD')).toBe('US$3.11')
   })
 })
 
@@ -44,11 +45,17 @@ describe('formatMemo', () => {
 })
 
 describe('formatEthRemaining', () => {
-  function getEthExchange(currency) {
+  function getEthExchange() {
     return 400
   }
 
   it('should return the correct amount of transfer capacity remaining', () => {
     expect(formatEthRemaining(getEthExchange, 0.123432, 'USD')).toBe('150.62')
+  })
+})
+
+describe('cleanFiatAmount', () => {
+  it('should return an amount in number format', () => {
+    expect(cleanFiatAmount('CA$1.21')).toBe(1.21)
   })
 })

--- a/__tests__/lndr/format.ts
+++ b/__tests__/lndr/format.ts
@@ -2,7 +2,8 @@ import 'react-native'
 
 // Note: test renderer must be required after react-native.
 
-import { commas, amountFormat } from 'lndr/format'
+import { commas, amountFormat, formatEthToFiat, formatCommaDecimal, formatSettlementAmount, formatMemo, formatEthRemaining } from 'lndr/format'
+import { getEthExchange } from 'reducers/app';
 
 describe('commas', () => {
   it('Applies the correct number of commas to a USD amount', () => {
@@ -17,5 +18,37 @@ describe('amountFormat', () => {
     expect(amountFormat('1000.10', 'INR')).toBe('₹1,000.10')
     expect(amountFormat('1,000.10', 'THB')).toBe('฿1,000.10')
     expect(amountFormat('1,0100.10', 'TRY')).toBe('₺10,100.10')
+  })
+})
+
+describe('formatEthToFiat', () => {
+  it('Formats an ETH amount correctly', () => {
+    expect(formatEthToFiat('2', '100.10', 'USD')).toBe(` (US$200.20)`)
+  })
+})
+
+describe('formatSettlementAmount', () => {
+  it('Formats an ETH amount correctly', () => {
+    expect(formatSettlementAmount('2', 110, 'USD')).toBe('US$1.10')
+    expect(formatSettlementAmount('1', 210, 'USD')).toBe('US$2.10')
+    expect(formatSettlementAmount('410', 410, 'USD')).toBe('US$4.10')
+    expect(formatSettlementAmount('3.11', 311, 'USD')).toBe('US$3.11')
+  })
+})
+
+describe('formatMemo', () => {
+  it('Formats a memo to 32 bytes', () => {
+    expect(formatMemo('this is far too long and I dont understand why it should be this long')).toBe('this is far too long and I dont ')
+    expect(formatMemo('just right')).toBe('just right')
+  })
+})
+
+describe('formatEthRemaining', () => {
+  function getEthExchange(currency) {
+    return 400
+  }
+
+  it('should return the correct amount of transfer capacity remaining', () => {
+    expect(formatEthRemaining(getEthExchange, 0.123432, 'USD')).toBe('150.62')
   })
 })

--- a/__tests__/ui/components/__snapshots__/AddFriendRow.tsx.snap
+++ b/__tests__/ui/components/__snapshots__/AddFriendRow.tsx.snap
@@ -84,16 +84,22 @@ exports[`Initialization renders correctly 1`] = `
             accessible={true}
             allowFontScaling={true}
             ellipsizeMode="tail"
+            numberOfLines={1}
             style={
-              Object {
-                "color": "#01c5d9",
-                "fontSize": 16,
-                "fontWeight": "bold",
-                "maxWidth": 375,
-              }
+              Array [
+                Object {
+                  "color": "#01c5d9",
+                  "fontSize": 16,
+                  "fontWeight": "bold",
+                  "maxWidth": 375,
+                },
+                Object {
+                  "maxWidth": 160,
+                },
+              ]
             }
           >
-            Joe
+            @Joe
           </Text>
         </View>
       </View>
@@ -153,15 +159,38 @@ exports[`Initialization renders correctly 1`] = `
               Object {
                 "borderRadius": 100,
               },
-              Object {
-                "marginRight": 10,
-              },
-              Object {
-                "width": 140,
-              },
             ]
           }
         >
+          <Text
+            accessible={true}
+            allowFontScaling={false}
+            ellipsizeMode="tail"
+            style={
+              Array [
+                Object {
+                  "color": undefined,
+                  "fontSize": 12,
+                },
+                Object {
+                  "backgroundColor": "transparent",
+                  "color": "#fff",
+                  "fontSize": 22,
+                  "height": 23,
+                  "marginLeft": -4,
+                  "padding": 0,
+                  "width": 23,
+                },
+                Object {
+                  "fontFamily": "Ionicons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+              ]
+            }
+          >
+            
+          </Text>
           <Text
             accessible={true}
             allowFontScaling={true}
@@ -180,13 +209,10 @@ exports[`Initialization renders correctly 1`] = `
                   "paddingRight": 10,
                   "textAlign": "center",
                 },
-                Object {
-                  "fontSize": 14,
-                },
               ]
             }
           >
-            + ADD FRIEND
+            ADD
           </Text>
         </View>
       </View>

--- a/packages/actions/index.ts
+++ b/packages/actions/index.ts
@@ -125,10 +125,12 @@ export const getAccountInformation = () => {
     const user = getUser(getState())()
 
     try {
-      const [ nickname, email ] = await Promise.all([creditProtocol.getNickname(user.address), creditProtocol.getEmail(user.address)])
-      user.nickname = nickname
-      user.email = email
-    } catch (e) { console.log('ERROR GETTING EMAIL OR NICKNAME: ', e) }
+      user.nickname = await creditProtocol.getNickname(user.address)
+    } catch (e) { console.log('ERROR GETTING NICKNAME: ', e) }
+
+    try {
+      user.email = await creditProtocol.getEmail(user.address)
+    } catch (e) { console.log('ERROR GETTING EMAIL: ', e) }
 
     await userStorage.set(user)
     dispatch(setState({ user }))

--- a/packages/actions/index.ts
+++ b/packages/actions/index.ts
@@ -482,7 +482,7 @@ export const getPayPalRequests = () => {
 
       return jsonToPayPalRequest({ requestorIsMe, friend })
     })
-  
+
     dispatch(setState({ payPalRequests, payPalRequestsLoaded: true }))
   }
 }
@@ -650,9 +650,7 @@ export const addDebt = (friend: Friend, amount: string, memo: string, direction:
       dispatch(displaySuccess(debtManagement.pending.success(friend)))
 
       return true
-    }
-
-    catch (e) {
+    } catch (e) {
       dispatch(displayError(debtManagement.pending.error))
     }
   }

--- a/packages/language/languages/ar.ts
+++ b/packages/language/languages/ar.ts
@@ -376,6 +376,18 @@ export default {
       start: ` بنجاح ورقم الهاش لمعاملتك هو `,
       end: ` لقد أرسلت  BCPT `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: ` حالة هذه المعاملة من تبويب النشاط`,
     activity: `يمكنك رؤية`,
   },

--- a/packages/language/languages/ar.ts
+++ b/packages/language/languages/ar.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `رصيد الإثيريوم الخاص بك هو ${String(Y).slice(0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `تعذر استرداد رصيد إثيريوم`,
       manage: `إدارة إثيريوم`,
     },
@@ -163,6 +162,7 @@ export default {
       `رصيد BCPT`,
       `إزالة الحساب`,
       `سجل معاملات إثيريوم`,
+      `تمكين باي بال`,
       `تغيير العملات الرئيسية`,
       `تغيير رمز PIN‏`,
       `تغيير الاسم المستعار`,

--- a/packages/language/languages/cs.ts
+++ b/packages/language/languages/cs.ts
@@ -376,6 +376,18 @@ export default {
       start: `Úspěšně jste odeslali `,
       end: ` BCPT a hash vaší transakce je `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `Stav této transakce můžete sledovat v `,
     activity: `záložce Aktivita.`,
   },

--- a/packages/language/languages/cs.ts
+++ b/packages/language/languages/cs.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Váš zůstatek ETH je ${String(Y).slice(0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Nelze načíst Eth rovnováhu`,
       manage: `Správovat ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `Zůstatek BCPT`,
       `Odstranit účet`,
       `ETH Transakční historie`,
+      `Umožnit PayPal`,
       `Změnit hlavní měně`,
       `Změna PIN`,
       `Změna přezdívky`,

--- a/packages/language/languages/da.ts
+++ b/packages/language/languages/da.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Din ETH saldo er ${String(Y).slice(0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Kunne ikke indlæse Eth saldo`,
       manage: `Administrer ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `BCPT Saldo`,
       `Fjern konto`,
       `ETH Transaktionshistorik`,
+      `Aktiver PayPal`,
       `Skift primære valuta`,
       `Skift PIN`,
       `Skift brugernavn`,

--- a/packages/language/languages/da.ts
+++ b/packages/language/languages/da.ts
@@ -376,6 +376,18 @@ export default {
       start: `Du har nu sendt `,
       end: ` BCPT og dit transaktion ID er `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `Du kan se statussen for denne transaktion `,
     activity: `i aktivitetsfanen.`,
   },

--- a/packages/language/languages/de.ts
+++ b/packages/language/languages/de.ts
@@ -379,6 +379,18 @@ export default {
       start: `Sie haben erfolgreich `,
       end: ` BCPT gesendet und Ihre Transaktion-Hash ist `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `Sie können den Status dieser Transaktion in der `,
     activity: `Aktivität-Registerkarte sehen.`,
   },

--- a/packages/language/languages/de.ts
+++ b/packages/language/languages/de.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Ihr ETH-Kontostand ist ${String (Y) .slice (0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Eth-Kontostand kann nicht abgerufen werden`,
       manage: `ETH verwalten`,
     },
@@ -132,7 +131,7 @@ export default {
         generic: `Es gab einen Fehler bei der Übertragung, bitte versuchen Sie es später noch einmal`,
         address: `Bitte geben Sie eine gültige Adresse ein`,
         amount: `Bitte geben Sie einen Betrag größer als 0 ein`,
-        limitExceeded: A => `Sie können nur ${CUR [A]} ${TL [A]} pro Woche senden, wählen Sie bitte einen kleineren Betrag`,
+        limitExceeded: A => `Sie können nur ${CUR(A)} ${TL(A)} pro Woche senden, wählen Sie bitte einen kleineren Betrag`,
       },
       amount: `Betrag, der gesendet werden soll`,
       address: `Zieladresse (ohne ‚0x‘ Präfix)`,
@@ -140,10 +139,13 @@ export default {
       transferAll: `Überweisen Sie alles`,
       balance: Y => `Ihr aktueller ETH-Kontostand ist ${typeof Y === 'string'? Y.slice (0,8): ''} `,
       ethAddress: `Ethereum-Adresse`,
-      txCost: (B, A) => `Die aktuelle Transaktion kostet ${CUR [A]} ${B}`,
+      txCost: (B, A) => {
+        console.log('AHWTEWT ',  A)
+        return `Die aktuelle Transaktion kostet ${CUR(A)} ${B}`}
+        ,
       transferLowercase: `Eth-Überweisung`,
-      note: A => `Bitte beachten Sie: Sie können nur ${CUR [A]} ${TL [A]} pro Woche aus Lndr überweisen`,
-      warning: (Z, A) => `Sie haben ${CUR [A]} ${Z} übrig von Ihrem ${CUR [A]} ${TL [A]} Limit`,
+      note: A => `Bitte beachten Sie: Sie können nur ${CUR(A)} ${TL(A)} pro Woche aus Lndr überweisen`,
+      warning: (Z, A) => `Sie haben ${CUR(A)} ${Z} übrig von Ihrem ${CUR(A)} ${TL(A)} Limit`,
     },
     sendBcpt: {
       error: {
@@ -163,6 +165,7 @@ export default {
       `BCPT-Kontostand`,
       `Konto Entfernen`,
       `ETH-Transaktionshistorie`,
+      `Aktivieren Sie PayPal`,
       `Hauptwährung ändern`,
       `PIN ändern`,
       `Nickname ändern`,

--- a/packages/language/languages/el.ts
+++ b/packages/language/languages/el.ts
@@ -376,6 +376,18 @@ export default {
       start: `Έχετε στείλει με επιτυχία `,
       end: ` BCPT και το hash της συναλλαγής σας είναι `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `Μπορείτε να δείτε την κατάσταση της συναλλαγής στην `,
     activity: `καρτέλα δραστηριότητας.`,
   },

--- a/packages/language/languages/el.ts
+++ b/packages/language/languages/el.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Το υπόλοιπο ETH σας είναι ${String(Y).slice (0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Αδυναμία ενημέρωσης υπολοίπου Eth`,
       manage: `Διαχείριση ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `Yπόλοιπο BCPT`,
       `Κατάργηση Λογαριασμού`,
       `Ιστορικό Συναλλαγών ETH`,
+      `Ενεργοποίηση PayPal`,
       `Αλλαγή Πρωτοβάθμια νομίσματος`,
       `Αλλαγή PIN`,
       `Αλλαγή Ψευδώνυμου`,

--- a/packages/language/languages/en.ts
+++ b/packages/language/languages/en.ts
@@ -119,7 +119,6 @@ export default {
     },
     ethBalance: {
       display: balance => `Your ETH balance is ${String(balance).slice(0,8)}`,
-      inFiat: (amount, exchange, currency) => ` (${currencySymbols(currency)}${String(Number(amount) * Number(exchange)).slice(0, 8)})`,
       getError: `Unable to retrieve Eth balance`,
       manage: `Manage ETH`,
     },

--- a/packages/language/languages/es.ts
+++ b/packages/language/languages/es.ts
@@ -376,6 +376,18 @@ export default {
       start: `Has enviado `,
       end: ` BCPT con éxito, y el hash de la transacción es `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `Puede ver el estado de esta transacción en la `,
     activity: `pestaña Actividad.`,
   },

--- a/packages/language/languages/es.ts
+++ b/packages/language/languages/es.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Su Saldo en ETH (Ethereum) es: ${String (Y) .slice (0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `No se pudo recuperar su balance de ETH (Ethereum)`,
       manage: `Administrar ETH (Ethereum)`,
     },
@@ -163,6 +162,7 @@ export default {
       `Saldo de BCPT`,
       `Eliminar Cuenta`,
       `Historial de Transacciones en Ethereum`,
+      `Activar PayPal`,
       `Cambiar divisa principal`,
       `Cambiar PIN`,
       `Cambio Nombre de Usuario`,

--- a/packages/language/languages/fi.ts
+++ b/packages/language/languages/fi.ts
@@ -377,6 +377,18 @@ export default {
       start: `Olet onnistuneesti lähettänyt `,
       end: ` BCPT:tä ja tapahtumasi tunnusnumero on `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `Tämän tapahtuman tila `,
     activity: `näkyy tapahtumavalikossa.`,
   },

--- a/packages/language/languages/fi.ts
+++ b/packages/language/languages/fi.ts
@@ -163,6 +163,7 @@ export default {
       `BCPT-saldo`,
       `Poista tili`,
       `ETH-tapahtumahistoria`,
+      `Ota PayPal`,
       `Muuta päävaluutta`,
       `Muuta PIN-koodisi`,
       `Muuta käyttäjänimesi`,

--- a/packages/language/languages/fr.ts
+++ b/packages/language/languages/fr.ts
@@ -376,6 +376,18 @@ export default {
       start: `Vous avez envoyé avec succès `,
       end: ` BCPT et le hachage de votre transaction est `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `Vous pouvez voir l'état de cette opération dans `,
     activity: `l'onglet d'activité.`,
   },

--- a/packages/language/languages/fr.ts
+++ b/packages/language/languages/fr.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Votre solde en ETH est de ${String (Y) .slice (0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Impossible de récupérer votre solde en ETH`,
       manage: `Gérer vos ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `Solde BCPT`,
       `Supprimer le compte`,
       `Historique des transactions en ETH`,
+      `Activer PayPal`,
       `Changer la devise primaire`,
       `Modifier le code PIN`,
       `Modifier le pseudonyme`,

--- a/packages/language/languages/hi.ts
+++ b/packages/language/languages/hi.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `आपका ETH बैलेन्स $ है ${String(Y).slice(0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Eth बैलेन्स प्राप्त नहीं कर पा रहा`,
       manage: `ETH मैनेज करें`,
     },
@@ -163,6 +162,7 @@ export default {
       `BCPT बैलेंस`,
       `अकाउंट डिलीट करें`,
       `ETH बैलेंस हिस्ट्री`,
+      `पेपैल सक्षम करें`,
       `प्राथमिक मुद्रा परिवर्तित करें`,
       `पिन बदलिए`,
       `छोटा नाम बदलें`,

--- a/packages/language/languages/hi.ts
+++ b/packages/language/languages/hi.ts
@@ -376,6 +376,18 @@ export default {
       start: `आपने `,
       end: ` BCPT भेज दिए हैं और आपका ट्रैंज़ैक्शन हैश `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `आप इस ट्रैंज़ैक्शन का स्टेटस एक्टिविटी टैब `,
     activity: `में देख सकते हैं।`,
   },

--- a/packages/language/languages/hu.ts
+++ b/packages/language/languages/hu.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `ETH egyenlege ${String (Y) .slice (0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Az Eth egyenleg lekérdezése nem sikerült`,
       manage: `ETH KEZELÉSE`,
     },
@@ -163,6 +162,7 @@ export default {
       `BCPT Egyenleg`,
       `Fiók Törlése`,
       `ETH Tranzakció Előzmények`,
+      `Engedélyezze a PayPalt`,
       `Megváltoztathatja az elsődleges pénzneme`,
       `PiN-kód Módosítása`,
       `Becenév Módosítása`,

--- a/packages/language/languages/hu.ts
+++ b/packages/language/languages/hu.ts
@@ -376,6 +376,18 @@ export default {
       start: `Sikeresen elküldött `,
       end: ` BCPT-t, és a tranzakciós hash `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `A tevékenység fülön megtekintheti a jelen `,
     activity: `tranzakció státuszát.`,
   },

--- a/packages/language/languages/in.ts
+++ b/packages/language/languages/in.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Saldo ETH Anda adalah ${String(Y).slice(0,8)}.`,
-      inFiat: (Z, B, A) => `(${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Tidak dapat memuat saldo ETH`,
       manage: `Kelola ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `Saldo BCPT`,
       `Hapus Akun`,
       `Riwayat Transaksi ETH`,
+      `Aktifkan PayPal`,
       `Ubah Mata Uang Primer`,
       `Ubah PIN`,
       `Ubah Nama Panggilan`,

--- a/packages/language/languages/in.ts
+++ b/packages/language/languages/in.ts
@@ -376,6 +376,18 @@ export default {
       start: `Anda berhasil mengirimkan `,
       end: ` BCPT, dan hash transaksi Anda adalah `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `Anda dapat melihat status transaksi ini di `,
     activity: `tab aktivitas.`,
   },

--- a/packages/language/languages/it.ts
+++ b/packages/language/languages/it.ts
@@ -376,6 +376,18 @@ export default {
       start: `Hai inviato con successo `,
       end: ` BCPT e l'hash per la transazione è `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `È possibile visualizzare lo stato di tale operazione nella `,
     activity: `scheda attività.`,
   },

--- a/packages/language/languages/it.ts
+++ b/packages/language/languages/it.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Il saldo ETH è ${String(Y).slice(0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Impossibile recuperare il saldo Eth`,
       manage: `Gestire ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `Saldo BCPT`,
       `Rimuovi l'account`,
       `Cronologia delle Transazioni ETH`,
+      `Abilita PayPal`,
       `Cambia primario valuta`,
       `Modifica PIN`,
       `Cambia soprannome`,

--- a/packages/language/languages/iw.ts
+++ b/packages/language/languages/iw.ts
@@ -376,6 +376,18 @@ export default {
       start: `שלחת BCPT `,
       end: `בהצלחה ומספר העסקה שלך הוא `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `אתה יכול לראות את סטטוס העסקה הזאת `,
     activity: `.בלשונית הפעילות`,
   },

--- a/packages/language/languages/iw.ts
+++ b/packages/language/languages/iw.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `${String(Y).slice(0,8)} שלך היא ETH -יתרת ה`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `לא ניתן לאחזר את יתרת Eth`,
       manage: `ניהול ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `יתרת BCPT`,
       `להסיר חשבון`,
       `היסטוריית עסקאות ETH`,
+      `הפוך את PayPal`,
       `שינוי מטבע ראשי`,
       `לשנות PIN`,
       `לשנות כינוי`,

--- a/packages/language/languages/ja.ts
+++ b/packages/language/languages/ja.ts
@@ -119,11 +119,6 @@ export default {
   },
   ethBalance: {
     display: balance => `あなたのETH残高はこちら ${String(balance).slice(0,8)} `,
-    inFiat: (amount, exchange, currency) => {
-      const strAmnt = String(Number(amount) * Number(exchange))
-      const perInd = strAmnt.indexOf('.') === -1 ? strAmnt.length : strAmnt.indexOf('.')
-      return ` (${currencySymbols(currency)}${strAmnt.slice(0, perInd)})`
-    },
     getError: `ETH残高を取得できません`,
     manage: `ETHを管理する`,
   },
@@ -164,6 +159,7 @@ export default {
     `BCPT残高`,
     `アカウントを削除する`,
     `ETHのやりとり履歴`,
+    `ペイパルを有効にします`,
     `プライマリ通貨を変更`,
     `暗証番号を変える`,
     `ニックネームを変える`,

--- a/packages/language/languages/ja.ts
+++ b/packages/language/languages/ja.ts
@@ -365,6 +365,18 @@ export default {
       start: `送信成功 `,
       end: ` あなたのBCPTとトランザクションハッシュは `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `取引のステータスを確認するにはここ `,
     activity: `アクティビティタブ.`,
   },

--- a/packages/language/languages/ko.ts
+++ b/packages/language/languages/ko.ts
@@ -365,6 +365,18 @@ export default {
       start: "성공적으로 보냈습니다 ",
       end: " BCPT 당신의 거래는 "
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `거래 내역을 볼 수 있는 곳은 `,
     activity: ` 액티비티 탭.`,
   },

--- a/packages/language/languages/ko.ts
+++ b/packages/language/languages/ko.ts
@@ -120,11 +120,6 @@ export default {
     },
     ethBalance: {
       display: balance => `당신의 이더리움 잔액은 ${String(balance).slice(0,8)} `,
-      inFiat: (amount, exchange, currency) => {
-        const strAmnt = String(Number(amount) * Number(exchange))
-        const perInd = strAmnt.indexOf('.') === -1 ? strAmnt.length : strAmnt.indexOf('.')
-        return ` (${currencySymbols(currency)}${strAmnt.slice(0, perInd)})`
-      },
       getError: `이더리움 잔액내역을 불러오지 못했습니다`,
       manage: `이더리움 관리`,
     },
@@ -163,8 +158,10 @@ export default {
       `이더리움 (& BCPT) 주소`,
       `이더리움 잔액`,
       `BCPT 잔액`,
+      `계정 삭제`,
       `이더리움 거래 내역`,
       `차 환율 변경`,
+      `페이팔 사용`,
       `비밀번호 변경`,
       `닉네임 변경`,
       `이메일 주소`,

--- a/packages/language/languages/ms.ts
+++ b/packages/language/languages/ms.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Baki ETH anda adalah ${String(Y).slice(0,8)}`,
-      inFiat: (Z, B, A) => `(${CUR[A]}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Tidak dapat mencari data baki ETH`,
       manage: `Uruskan ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `Baki BCPT`,
       `Hapus Akaun`,
       `Sejarah Transaksi ETH`,
+      `Membolehkan PayPal`,
       `Tukar Mata Wang Utama`,
       `Tukar PIN`,
       `Tukar Nama Samaran`,

--- a/packages/language/languages/ms.ts
+++ b/packages/language/languages/ms.ts
@@ -376,6 +376,18 @@ export default {
       start: `Anda telah berjaya menghantar `,
       end: ` BCPT dan cincangan transaksi anda adalah `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `Anda boleh melihat status transaksi ini dalam tab `,
     activity: `aktiviti tersebut.`,
   },

--- a/packages/language/languages/nb.ts
+++ b/packages/language/languages/nb.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Din ETH saldo er ${String(Y).slice(0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Kan ikke hente Eth saldoen`,
       manage: `Administrer ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `BCPT Balance`,
       `Fjern konto`,
       `ETH Transaksjonshistorikk`,
+      `Aktiver PayPal`,
       `Endre Primær Valuta`,
       `Endre PIN-kode`,
       `Endre kallenavn`,

--- a/packages/language/languages/nb.ts
+++ b/packages/language/languages/nb.ts
@@ -375,6 +375,18 @@ export default {
       start: `Du har sendt `,
       end: ` BCPT og transaksjonens referanse er `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `Du kan se statusen for denne transaksjonen `,
     activity: `i aktivitetsfanen.`,
   },

--- a/packages/language/languages/nl.ts
+++ b/packages/language/languages/nl.ts
@@ -375,6 +375,18 @@ export default {
       start: `U heeft succesvol `,
       end: ` BCPT verzonden en uw transactiekenmerk is `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `U kunt de status van deze transactie zien in het `,
     activity: `tabblad activiteit.`,
   },

--- a/packages/language/languages/nl.ts
+++ b/packages/language/languages/nl.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Uw ETH saldo is ${String(Y).slice(0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Kan Eth balans niet ophalen`,
       manage: `Beheer ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `BCPT saldo`,
       `Verwijder account`,
       `ETH transactiegeschiedenis`,
+      `Inschakelen PayPal`,
       `Wijzig primaire valuta`,
       `Wijzig pincode`,
       `Wijzig gebruikersnaam`,

--- a/packages/language/languages/no.ts
+++ b/packages/language/languages/no.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Din ETH saldo er ${String(Y).slice(0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Kan ikke hente Eth saldoen`,
       manage: `Administrer ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `BCPT Balance`,
       `Fjern konto`,
       `ETH Transaksjonshistorikk`,
+      `Aktiver PayPal`,
       `Endre Primær Valuta`,
       `Endre PIN-kode`,
       `Endre kallenavn`,

--- a/packages/language/languages/no.ts
+++ b/packages/language/languages/no.ts
@@ -375,6 +375,18 @@ export default {
       start: `Du har sendt `,
       end: ` BCPT og transaksjonens referanse er `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `Du kan se statusen for denne transaksjonen `,
     activity: `i aktivitetsfanen.`,
   },

--- a/packages/language/languages/pl.ts
+++ b/packages/language/languages/pl.ts
@@ -375,6 +375,18 @@ export default {
       start: `Udało się wysłać `,
       end: ` BCPT, hash dla tej transakcji to `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `Można sprawdzić status transakcji w `,
     activity: `zakładce aktywności.`,
   },

--- a/packages/language/languages/pl.ts
+++ b/packages/language/languages/pl.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Bilans ETH wynosi ${String (Y) .slice (0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Nie udało się uzyskać bilansu Eth`,
       manage: `Zarządzaj ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `Bilans BCPT`,
       `Usuń Konto`,
       `Historia transakcji ETH`,
+      `Włącz PayPal`,
       `Zmień walutę podstawowy`,
       `Zmień PIN`,
       `Zmień Nazwę Użytkownika`,

--- a/packages/language/languages/pt.ts
+++ b/packages/language/languages/pt.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Seu saldo ETH é de R ${String (Y) .slice (0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Não é possível recuperar o saldo Eth`,
       manage: `Gerenciar ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `Balanço BCPT`,
       `Remover conta`,
       `Histórico de Transações ETH`,
+      `Ativar PayPal`,
       `Alterar Moeda principal`,
       `Alterar PIN`,
       `Alterar Nome de utilizador`,

--- a/packages/language/languages/pt.ts
+++ b/packages/language/languages/pt.ts
@@ -375,6 +375,18 @@ export default {
       start: `Você enviou com sucesso `,
       end: ` BCPT e seu hash de transação é `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `Você pode ver o status da operação na aba atividade.`,
     activity: `.`,
   },

--- a/packages/language/languages/ru.ts
+++ b/packages/language/languages/ru.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Ваш ETH баланс ${String (Y) .slice (0,8)} `,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Невозможно получить ETH баланс`,
       manage: `Управление ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `BCPT Баланс`,
       `Удалить учетную запись`,
       `История транзакций ETH`,
+      `Включить PayPal`,
       `Изменение первичной валюты`,
       `Измененить ПИН-код`,
       `Изменить Прозвище`,

--- a/packages/language/languages/ru.ts
+++ b/packages/language/languages/ru.ts
@@ -375,6 +375,18 @@ export default {
       start: `Вы успешно отправили `,
       end: ` BCPT, а хеш транзакции `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `Статус этой транзакции можно увидеть на вкладке `,
     activity: `«Активность».`,
   },

--- a/packages/language/languages/sv.ts
+++ b/packages/language/languages/sv.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Ditt ETH saldo är ${String (Y) .slice (0,8)} `,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Det gick inte att inhämta Eth saldo`,
       manage: `Hantera ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `BCPT Saldo`,
       `Ta bort konto`,
       `ETH Transaktionshistorik`,
+      `Aktivera PayPal`,
       `Ändra primära valuta`,
       `Ändra PIN-kod`,
       `Ändra användarnamn`,

--- a/packages/language/languages/sv.ts
+++ b/packages/language/languages/sv.ts
@@ -375,6 +375,18 @@ export default {
       start: `Du har framgångsrikt skickat `,
       end: ` BCPT och din transaktionshash är `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `Du kan se status för denna `,
     activity: `transaktion på aktivitetsfliken.`,
   },

--- a/packages/language/languages/th.ts
+++ b/packages/language/languages/th.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `ยอด ETH คงเหลือของคุณคือ ${String(Y).slice(0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `ไม่สามารถเรียกข้อมูลยอด ETH คงเหลือคืนมาได้ `,
       manage: `จัดการ ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `ยอด BCPT คงเหลือ`,
       `ปิดบัญชี`,
       `ประวัติการทำธุรกรรม ETH`,
+      `เปิดใช้งาน PayPal`,
       `เปลี่ยนสกุลเงินหลัก`,
       `เปลี่ยน PIN`,
       `เปลี่ยนชื่อเล่น`,

--- a/packages/language/languages/th.ts
+++ b/packages/language/languages/th.ts
@@ -375,6 +375,18 @@ export default {
       start: `คุณได้ส่ง `,
       end: ` BCPT เรียบร้อยแล้ว และแฮชธุรกรรมของคุณคือ `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `คุณสามารถดูสถานะของธุรกร`,
     activity: `รมนี้ได้ในแท็บกิจกรรม.`,
   },

--- a/packages/language/languages/tr.ts
+++ b/packages/language/languages/tr.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `ETH bakiyeniz ${String (Y) .slice (0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Eth bakiyesi çekilemedi`,
       manage: `ETH yönetimi`,
     },
@@ -163,6 +162,7 @@ export default {
       `BCPT Bakiyesi`,
       `Hesabı Kaldır`,
       `ETH İşlem Geçmişi`,
+      `Paypal etkinleştirme`,
       `Birincil Para değiştirme`,
       `Pin'i Değiştir`,
       `Kullanıcı Adını Değiştir`,

--- a/packages/language/languages/tr.ts
+++ b/packages/language/languages/tr.ts
@@ -375,6 +375,18 @@ export default {
       start: `Başarıyla `,
       end: ` BCPT gönderdiniz ve işlem sağlama kodunuz `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: ``,
     activity: `Hareketler sekmesinde bu işlemin durumunu görebilirsiniz.`,
   },

--- a/packages/language/languages/vi.ts
+++ b/packages/language/languages/vi.ts
@@ -375,6 +375,18 @@ export default {
       start: `Bạn đã gửi thành công `,
       end: ` BCPT và mã hóa giao dịch của bạn là `,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `Bạn có thể xem trạng thái của giao dịch này trong `,
     activity: `tab hoạt động.`,
   },

--- a/packages/language/languages/vi.ts
+++ b/packages/language/languages/vi.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y => `Số dư ETH của bạn là ${String(Y).slice(0,8)}`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `Không thể lấy số dư Eth`,
       manage: `Quản lý ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `Số dư BCPT`,
       `Xoá tài khoản`,
       `Lịch sử giao dịch ETH`,
+      `Bật PayPal`,
       `Thay đổi tiền tệ chính`,
       `Thay đổi mã PIN`,
       `Thay đổi Biệt danh`,

--- a/packages/language/languages/zh-CN.ts
+++ b/packages/language/languages/zh-CN.ts
@@ -122,7 +122,6 @@ export default {
     },
     ethBalance: {
       display: Y =>`你ETH余额是${String(Y).slice(0,8) }`,
-      inFiat: (Z, B, A) => ` (${CUR(A)}${String(Number(Z) * Number(B)).slice(0, 8)})`,
       getError: `检索的Eth有错误`,
       manage: `管理ETH`,
     },
@@ -163,6 +162,7 @@ export default {
       `BCPT平衡`,
       `删除帐户`,
       `ETH交易记录`,
+      `启用贝宝`,
       `更改主货币`,
       `更改密码`,
       `更改昵称`,

--- a/packages/language/languages/zh-CN.ts
+++ b/packages/language/languages/zh-CN.ts
@@ -375,6 +375,18 @@ export default {
       start: `您发送`,
       end: `BCPT和您的交易记录号是`,
     },
+    requestPayPalPayee: {
+      start: `We've let `,
+      end: ` know that you would like to settle with PayPal.`,
+    },
+    requestPayPalPayment: {
+      start: `We've let `,
+      end: ` know that you'd like to be paid with PayPal.`,
+    },
+    settledWithPayPal: {
+      start: `We've let `,
+      end: ` know that you've settled with PayPal.`,
+    },
     status: `你可以在活动选项卡看到`,
     activity: `这个交易的状态。`,
   },

--- a/packages/lndr/format/index.ts
+++ b/packages/lndr/format/index.ts
@@ -156,7 +156,13 @@ export const formatLockTimeout = timeout => timeout.replace(/[^0-9]/g, '')
 
 export const ethAddress = addr => addr.replace(/[g-z]/gi, '').replace(/[^a-z0-9]/gi, '').toLowerCase()
 
-export const ethAmount = amount => amount.replace(/[^0-9\.]/g, '')
+export const ethAmount = amount => {
+  if(isCommaDecimal()) {
+    return amount.replace(/[^0-9,]/g, '')
+  } else {
+    return amount.replace(/[^0-9\.]/g, '')
+  }
+}
 
 export const emailFormatIncorrect = email => !( /^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i.test(email) )
 

--- a/packages/lndr/format/index.ts
+++ b/packages/lndr/format/index.ts
@@ -236,5 +236,9 @@ export const cleanFiatAmount = (amount: string) : number => {
   } else {
     amount = amount.replace(',', '')
   }
-  return Number(amount.replace(/[^0-9\.]/g, ''))
+  const cleanAmount = amount.replace(/[^0-9\.]/g, '')
+  if(cleanAmount.slice(-1) === '.') {
+    return 0
+  }
+  return Number(cleanAmount)
 }

--- a/packages/lndr/format/index.ts
+++ b/packages/lndr/format/index.ts
@@ -1,4 +1,4 @@
-import { currencySymbols, hasNoDecimals, isCommaDecimal } from 'lndr/currencies'
+import { currencySymbols, hasNoDecimals, isCommaDecimal, transferLimits } from 'lndr/currencies'
 
 declare const Buffer
 
@@ -187,4 +187,37 @@ export const convertCommaDecimalToPoint = (amount: string) : string => {
     return amount.slice(0, -2).replace(/\./, ',').concat('.').concat(end)
   }
   return amount
+}
+
+export const formatEthToFiat = (ethBalance: string, ethExchange: string, currency: string) : string => {
+  let converted = String( Number(ethBalance) * Number(ethExchange) ).slice(0, 8)
+  if(converted.slice(-2, -1) === '.') {
+    converted = converted + '0'
+  } else if(converted.slice(-1) === '.') {
+    converted = converted.slice(-1)
+  }
+  
+  return ` (${currencySymbols(currency)}${isCommaDecimal() ? converted.replace('.', ',') : converted})`
+}
+
+export const formatCommaDecimal = (amount: string) : string => isCommaDecimal() ? amount.replace('.', ',') : amount
+
+export const formatSettlementAmount = (amount: string, balance: number, primaryCurrency: string) : string => {
+  const adjustedBalance = hasNoDecimals(primaryCurrency) ? balance : balance / 100
+
+  const commaAdjusted = isCommaDecimal() ? String(adjustedBalance).replace('.', ',') : String(adjustedBalance)
+
+  let formattedAmount = amountFormat(commaAdjusted, primaryCurrency)
+  
+  if(amount && (formattedAmount.slice(-2, -1) === ',' || formattedAmount.slice(-2, -1) === '.')) {
+    formattedAmount += '0'
+  }
+  
+  return formattedAmount
+}
+
+export const formatEthRemaining = (ethExchange: Function, ethSentPastWeek: number, primaryCurrency: string) => {
+  const remaining = String(Number(transferLimits(primaryCurrency)) - Number(ethSentPastWeek) * Number(ethExchange(primaryCurrency)))
+  const end = remaining.indexOf('.') === -1 ? remaining.length : remaining.indexOf('.') + 3
+  return isCommaDecimal() ? remaining.slice(0, end).replace('.', ',') : remaining.slice(0, end)
 }

--- a/packages/ui/dialogs/add-debt/index.tsx
+++ b/packages/ui/dialogs/add-debt/index.tsx
@@ -110,14 +110,11 @@ class AddDebt extends Component<Props, State> {
   }
 
   blurCurrencyFormat() {
-    let { amount } = this.state
-    if(amount && (amount === ',' || amount === '.')) {
+    let { amount, currency } = this.state
+    if(amount === undefined || amount === '' || (amount && (amount === ',' || amount === '.'))) {
       this.setState({ amount: undefined })
-    } else if(amount && (amount.slice(-1) === ',' || amount.slice(-1) === '.')) {
-      amount = amount.slice(0, -1)
-      this.setState({ amount })
-    } else if(amount && (amount.slice(-2, -1) === ',' || amount.slice(-2, -1) === '.')) {
-      amount += '0'
+    } else {
+      amount = amountFormat(amount, currency, true)
       this.setState({ amount })
     }
   }
@@ -198,8 +195,7 @@ class AddDebt extends Component<Props, State> {
 
   setAmount(amount) {
     const { currency } = this.state
-    console.log(1, amount, currency)
-    return amountFormat(amount, currency)
+    return amountFormat(amount, currency, false)
   }
 
   handlePickerDone(value) {

--- a/packages/ui/dialogs/my-account/index.tsx
+++ b/packages/ui/dialogs/my-account/index.tsx
@@ -14,7 +14,7 @@ import BMLogo from 'ui/components/images/bm-logo'
 import InputImage from 'ui/components/images/input-image'
 import SpinningPicker from 'ui/components/spinning-picker'
 
-import { formatNick, formatLockTimeout, formatEmail, emailFormatIncorrect } from 'lndr/format'
+import { formatNick, formatLockTimeout, formatEmail, emailFormatIncorrect, formatCommaDecimal } from 'lndr/format'
 import { UpdateAccountData, UserData } from 'lndr/user'
 
 import { updateNickname, updateEmail, logoutAccount, toggleNotifications, getAccountInformation,
@@ -340,7 +340,7 @@ class MyAccount extends Component<Props, State> {
       </View>),
       (<View style={style.spaceHorizontalL}>
         <Text style={[style.text, style.spaceTopL, style.center]}>{currentBalance.eth}</Text>
-        <Text selectable style={style.displayText}>{ethBalance}</Text>
+        <Text selectable style={style.displayText}>{formatCommaDecimal(ethBalance)}</Text>
         <Button round onPress={() => this.props.navigation.navigate('TransferEth')} text={accountManagement.sendEth.transfer} />
       </View>),
       (<View style={style.spaceHorizontalL}>

--- a/packages/ui/dialogs/pending-settlement-detail/index.tsx
+++ b/packages/ui/dialogs/pending-settlement-detail/index.tsx
@@ -4,7 +4,7 @@ import { Text, View, Image, ScrollView } from 'react-native'
 import { getResetAction } from 'reducers/nav'
 
 import { UserData } from 'lndr/user'
-import { currencyFormats } from 'lndr/format'
+import { currencyFormats, formatCommaDecimal, formatEthRemaining } from 'lndr/format'
 import PendingUnilateral from 'lndr/pending-unilateral'
 import profilePic from 'lndr/profile-pic'
 import Friend from 'lndr/friend'
@@ -212,10 +212,7 @@ class PendingSettlementDetail extends Component<Props, State> {
 
   getLimit() {
     const { ethExchange, ethSentPastWeek, primaryCurrency } = this.props
-
-    const remaining = String(Number(transferLimits(primaryCurrency)) - Number(ethSentPastWeek) * Number(ethExchange(primaryCurrency)))
-    const end = remaining.indexOf('.') === -1 ? remaining.length : remaining.indexOf('.') + 3
-    return remaining.slice(0, end)
+    return formatEthRemaining(ethExchange, ethSentPastWeek, primaryCurrency)
   }
 
   render() {
@@ -246,7 +243,7 @@ class PendingSettlementDetail extends Component<Props, State> {
           }
           <View style={{marginBottom: 20}}/>
           {user.address === pendingSettlement.debtorAddress ? null : <Text style={[formStyle.smallText, formStyle.spaceTop, formStyle.center]}>{accountManagement.sendEth.warning(this.getLimit(), primaryCurrency)}</Text>}
-          <Text style={[accountStyle.txCost, formStyle.spaceBottom, {marginLeft: '2%'}]}>{accountManagement.sendEth.txCost(txCost, primaryCurrency)}</Text>
+          <Text style={[accountStyle.txCost, formStyle.spaceBottom, {marginLeft: '2%'}]}>{accountManagement.sendEth.txCost(formatCommaDecimal(txCost), primaryCurrency)}</Text>
           { confirmationError && <Text style={[formStyle.warningText, {alignSelf: 'center'}]}>{confirmationError}</Text>}
           {this.showButtons()}
           <View style={general.spaceBelow}/>

--- a/packages/ui/dialogs/settlement/index.tsx
+++ b/packages/ui/dialogs/settlement/index.tsx
@@ -232,6 +232,7 @@ class Settlement extends Component<Props, State> {
     let formInputError
 
     const cleanAmount = cleanFiatAmount(amount)
+    console.log('clean ', cleanAmount)
     const totalEthCost = ( Number(txCost) + cleanAmount ) / Number(ethExchange(primaryCurrency))
     const ethCost = String(totalEthCost)
 

--- a/packages/ui/dialogs/transfer-bcpt/index.tsx
+++ b/packages/ui/dialogs/transfer-bcpt/index.tsx
@@ -4,7 +4,7 @@ import { Text, TextInput, View, ScrollView, KeyboardAvoidingView, Platform } fro
 import { getResetAction } from 'reducers/nav'
 
 import { UserData } from 'lndr/user'
-import { bcptAmount, ethAddress } from 'lndr/format'
+import { bcptAmount, ethAddress, formatCommaDecimal } from 'lndr/format'
 
 import Button from 'ui/components/button'
 import Loading, { LoadingContext } from 'ui/components/loading'
@@ -146,7 +146,7 @@ class TransferBcpt extends Component<Props, State> {
                     onChangeText={amount => this.setState({ amount: this.setAmount(amount) })}
                   />
                 </View>
-                <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(txCost, primaryCurrency)}</Text>
+                <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(formatCommaDecimal(txCost), primaryCurrency)}</Text>
               </View>
             </View>
             { !!formInputError && <Text style={formStyle.warningText}>{formInputError}</Text>}

--- a/packages/ui/dialogs/transfer-eth/index.tsx
+++ b/packages/ui/dialogs/transfer-eth/index.tsx
@@ -27,13 +27,13 @@ import { connect } from 'react-redux'
 const sendingEthLoader = new LoadingContext()
 
 interface Props {
-  sendEth: (address: string, amount: string) => any
   user: UserData
   ethBalance: string
   ethSentPastWeek: number
-  ethExchange: (currency: string) => string
   navigation: any
   primaryCurrency: string
+  ethExchange: (currency: string) => string
+  sendEth: (address: string, amount: string) => any
 }
 
 interface State {
@@ -114,25 +114,24 @@ class TransferEth extends Component<Props, State> {
   }
 
   getLimit() {
-    const { formInputError } = this.state
     const { ethExchange, ethSentPastWeek, primaryCurrency } = this.props
     const remaining = String(Number(transferLimits(primaryCurrency)) - Number(ethSentPastWeek) * Number(ethExchange(primaryCurrency)))
     const end = remaining.indexOf('.') === -1 ? remaining.length : remaining.indexOf('.') + 3
     return remaining.slice(0, end)
   }
 
-  toFiat(amount, exchange, primaryCurrency) {
+  toFiat(amount, exchange) {
     if (amount === undefined) {
       amount = '0'
     }
-    const remaining = `${currencySymbols(primaryCurrency)}${Number(amount) * Number(exchange)}`
+    const remaining = `${Number(amount) * Number(exchange)}`
     const end = remaining.indexOf('.') === -1 ? remaining.length : remaining.indexOf('.') + 3
     return remaining.slice(0, end)
   }
 
   render() {
     const { amount, address, txCost, formInputError } = this.state
-    const { ethBalance, ethExchange, ethSentPastWeek, primaryCurrency } = this.props
+    const { ethBalance, ethExchange, primaryCurrency } = this.props
 
     return <View style={general.whiteFlex}>
       <View style={general.view}>
@@ -172,7 +171,7 @@ class TransferEth extends Component<Props, State> {
                   />
                 </View>
               </View>
-              <Text style={[formStyle.smallText, formStyle.center, formStyle.spaceTopS]}>{this.toFiat(amount, ethExchange(primaryCurrency), primaryCurrency)}</Text>
+              <Text style={[formStyle.smallText, formStyle.center, formStyle.spaceTopS]}>{`${currencySymbols(primaryCurrency)}${this.toFiat(amount, ethExchange(primaryCurrency))}`}</Text>
               <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(txCost, primaryCurrency)}</Text>
             </View>
             { formInputError && <Text style={[formStyle.warningText, {alignSelf: 'center'}]}>{formInputError}</Text>}

--- a/packages/ui/dialogs/transfer-eth/index.tsx
+++ b/packages/ui/dialogs/transfer-eth/index.tsx
@@ -4,7 +4,7 @@ import { Text, TextInput, View, ScrollView, KeyboardAvoidingView, Platform } fro
 import { getResetAction } from 'reducers/nav'
 
 import { UserData } from 'lndr/user'
-import { ethAmount, ethAddress } from 'lndr/format'
+import { ethAmount, ethAddress, formatCommaDecimal, formatEthRemaining } from 'lndr/format'
 import { currencySymbols, transferLimits, isCommaDecimal } from 'lndr/currencies'
 
 import Button from 'ui/components/button'
@@ -117,9 +117,7 @@ class TransferEth extends Component<Props, State> {
 
   getLimit() {
     const { ethExchange, ethSentPastWeek, primaryCurrency } = this.props
-    const remaining = String(Number(transferLimits(primaryCurrency)) - Number(ethSentPastWeek) * Number(ethExchange(primaryCurrency)))
-    const end = remaining.indexOf('.') === -1 ? remaining.length : remaining.indexOf('.') + 3
-    return remaining.slice(0, end)
+    return formatEthRemaining(ethExchange, ethSentPastWeek, primaryCurrency)
   }
 
   toFiat(amount: string | undefined, exchange: string) {
@@ -157,7 +155,7 @@ class TransferEth extends Component<Props, State> {
           <View style={general.largeHMargin} >
             <View style={[general.centeredColumn, {marginBottom: 20}]}>
               <View style={general.centeredColumn} >
-                <Text style={[formStyle.header, {textAlign: 'center'}]}>{accountManagement.sendEth.balance(ethBalance)}</Text>
+                <Text style={[formStyle.header, {textAlign: 'center'}]}>{accountManagement.sendEth.balance(formatCommaDecimal(ethBalance))}</Text>
                 <View style={formStyle.textInputContainer}>
                   <TextInput
                     style={[formStyle.textInput,  {paddingVertical: 3}]}
@@ -186,7 +184,7 @@ class TransferEth extends Component<Props, State> {
                 </View>
               </View>
               <Text style={[formStyle.smallText, formStyle.center, formStyle.spaceTopS]}>{`${currencySymbols(primaryCurrency)}${this.toFiat(amount, ethExchange(primaryCurrency))}`}</Text>
-              <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(txCost, primaryCurrency)}</Text>
+              <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(formatCommaDecimal(txCost), primaryCurrency)}</Text>
             </View>
             { formInputError && <Text style={[formStyle.warningText, {alignSelf: 'center'}]}>{formInputError}</Text>}
             <Button large round wide onPress={() => this.submit()} text={accountManagement.sendEth.transfer} />

--- a/packages/ui/dialogs/transfer-eth/index.tsx
+++ b/packages/ui/dialogs/transfer-eth/index.tsx
@@ -128,7 +128,8 @@ class TransferEth extends Component<Props, State> {
     }
     const remaining = `${Number(amount) * Number(exchange)}`
     const end = remaining.indexOf('.') === -1 ? remaining.length : remaining.indexOf('.') + 3
-    const result = remaining.slice(0, end)
+    let result = remaining.slice(0, end)
+    result = result.slice(-2, -1) === '.' ? result += '0' : result
     return isCommaDecimal() ? result.replace('.', ',') : result
   }
 

--- a/packages/ui/views/account/home/index.tsx
+++ b/packages/ui/views/account/home/index.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 
 import { Text, View, ScrollView, Platform, Dimensions, Image, TouchableHighlight, RefreshControl } from 'react-native'
 
-import { currencyFormats } from 'lndr/format'
+import { currencyFormats, formatEthToFiat, formatCommaDecimal } from 'lndr/format'
 import Balance from 'lndr/balance'
 
 import Button from 'ui/components/button'
@@ -205,9 +205,9 @@ class HomeView extends Component<Props, State> {
         />
       </View>
       <View style={[style.balanceRow, {marginTop: 10}]}>
-        <Text style={[style.balance, {marginLeft: '2%'}]}>{accountManagement.ethBalance.display(ethBalance)}</Text>
+        <Text style={[style.balance, {marginLeft: '2%'}]}>{accountManagement.ethBalance.display(formatCommaDecimal(ethBalance))}</Text>
         <Button alternate blackText narrow arrow small onPress={() => {this.props.navigation.navigate('MyAccount')}}
-          text={accountManagement.ethBalance.inFiat(ethBalance, ethExchange(primaryCurrency), primaryCurrency)}
+          text={formatEthToFiat(ethBalance, ethExchange(primaryCurrency), primaryCurrency)}
           containerStyle={{marginTop: -6}}
         />
       </View>


### PR DESCRIPTION
 1. Problem: The ETH tx cost is not displaying correctly in the correct currency on the Transfer ETH and Transfer BCPT dialogs. https://blockmason.atlassian.net/secure/RapidBoard.jspa?rapidView=9&projectKey=ENG&selectedIssue=ENG-155
 2. Solution: Add the ETH tx cost to the BCPT dialog and fix the display on the Transfer ETH page
 3. No concerns
 4. No blockers