### PR TITLE
Added call to getFriendRequests on home screen and fixed error with search friend avatar

### DIFF
--- a/packages/theme/form.ts
+++ b/packages/theme/form.ts
@@ -285,5 +285,13 @@ export default StyleSheet.create({
   },
   centerText: {
     textAlign: 'center'
+  },
+  emptyState: {
+    ...verticalMargin,
+    ...medium,
+    ...center,
+    color: gray,
+    fontStyle: 'italic',
+    marginTop: 30
   }
 } as any)

--- a/packages/ui/components/add-friend-row/index.tsx
+++ b/packages/ui/components/add-friend-row/index.tsx
@@ -23,22 +23,31 @@ interface State {
   pic?: string
 }
 
-export default class FriendRow extends Component<Props, State> {
+let unmounting = false;
+
+export default class AddFriendRow extends Component<Props, State> {
   constructor(props) {
     super(props)
     this.state = {}
   }
 
   async componentWillMount() {
-    const { friend } = this.props
+    const { friend, selected } = this.props
     let pic
+
+    unmounting = false;
 
     try {
       pic = await profilePic.get(friend.address)
     } catch (e) {}
-    if (pic) {
-      this.setState(pic)
+    
+    if ((!unmounting || selected) && pic) {
+      this.setState({ pic })
     }
+  }
+
+  componentWillUnmount() {
+    unmounting = true;
   }
 
   addFriendButton() {
@@ -51,7 +60,7 @@ export default class FriendRow extends Component<Props, State> {
     const { friend, selected, onPress } = this.props
     const { pic } = this.state
     const imageSource = pic ? { uri: pic } : require('images/person-outline-dark.png')
-
+    
     return (
       <TouchableHighlight onPress={onPress}>
         <View style={friendStyle.searchRow} >
@@ -59,7 +68,7 @@ export default class FriendRow extends Component<Props, State> {
             <View style={[general.flexRow, general.alignCenter]}>
               <Image source={imageSource} style={style.friendIcon}/>
               <View style={general.flexColumn}>
-                <Text style={style.titledPending}>{friend.nickname}</Text>
+                <Text style={style.titledPending}>{`@${friend.nickname}`}</Text>
               </View>
             </View>
             {!selected && this.addFriendButton()}

--- a/packages/ui/components/friend-row/index.tsx
+++ b/packages/ui/components/friend-row/index.tsx
@@ -30,11 +30,11 @@ interface Props {
   primaryCurrency: string
 }
 
-let unmounting = false;
-
 interface State {
   pic?: string
 }
+
+let unmounting = false;
 
 class FriendRow extends Component<Props, State> {
   constructor(props) {

--- a/packages/ui/views/account/friends/search-friend/index.tsx
+++ b/packages/ui/views/account/friends/search-friend/index.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 
-import { Text, TextInput, TouchableHighlight, View, ScrollView } from 'react-native'
+import { Text, TextInput, View, ScrollView } from 'react-native'
 
 import { debounce } from 'lndr/time'
 import { minimumNicknameLength } from 'lndr/user'
@@ -19,7 +19,6 @@ import general from 'theme/general'
 import language from 'language'
 const {
   nickname,
-  cancel,
   back,
   noMatches,
   addFriendConfirmationQuestion
@@ -27,7 +26,6 @@ const {
 const addFriendText = language.addFriend
 
 import { searchUsers } from 'actions'
-import { connect } from 'react-redux'
 
 const loadingContext = new LoadingContext()
 

--- a/packages/ui/views/account/friends/search-friend/index.tsx
+++ b/packages/ui/views/account/friends/search-friend/index.tsx
@@ -143,7 +143,7 @@ export default class SearchFriend extends Component<Props, State> {
       { hasSearchTerm &&
       <View style={friendStyle.searchList}>
         <Loading context={loadingContext} />
-        {hasSearchTerm && matches.length === 0 ? <Text style={[style.emptyState, {paddingLeft: 30}]}>{noMatches}</Text> : null}
+        {hasSearchTerm && matches.length === 0 ? <Text style={style.emptyState}>{noMatches}</Text> : null}
         {matches.map(
           match => {
             if (match.address === address || (addDebt && !this.isFriend(match)) ) {

--- a/packages/ui/views/account/home/index.tsx
+++ b/packages/ui/views/account/home/index.tsx
@@ -18,7 +18,7 @@ import Friend from 'lndr/friend'
 import { isFocusingOn } from 'reducers/nav'
 import { getStore, getUser, getNeedsReviewCount, calculateBalance, calculateCounterparties,
   getPrimaryCurrency, getFriendList, getPendingFromFriend, getEthExchange, getFriendFromNick } from 'reducers/app'
-import { getAccountInformation, displayError, getPending, getFriends,
+import { getAccountInformation, displayError, getPending, getFriends, getFriendRequests,
   getRecentTransactions, registerChannelID, getPayPalRequests } from 'actions'
 import { UrbanAirship } from 'urbanairship-react-native'
 import { currencySymbols } from 'lndr/currencies'
@@ -46,10 +46,18 @@ const loadingRecentTransactions = new LoadingContext()
 const loadingPending = new LoadingContext()
 const loadingFriends = new LoadingContext()
 const loadingPayPalRequests = new LoadingContext()
+const loadingFriendRequests = new LoadingContext()
 
 interface Props {
   navigation: any
   isFocused: boolean
+  user: UserData
+  state: any
+  needsReviewCount: number
+  primaryCurrency: string
+  friendList: Friend[]
+  calculateBalance: () => number
+  calculateCounterparties: () => number
   getPending: () => any
   getFriends: () => any
   getPayPalRequests: () => any
@@ -58,16 +66,10 @@ interface Props {
   getBalances: () => any
   displayError: (errorMsg: string) => any
   registerChannelID: (channelID: string, platform: string) => any
-  user: UserData
-  state: any
-  needsReviewCount: number
-  calculateBalance: () => number
-  calculateCounterparties: () => number
-  primaryCurrency: string
-  friendList: Friend[]
   getPendingFromFriend: (friendNickname: string) => any
   ethExchange: (currency: string) => string
   getFriendFromNick: (nickname: string) => Friend | undefined
+  getFriendRequests: () => void
 }
 
 interface State {
@@ -95,6 +97,7 @@ class HomeView extends Component<Props, State> {
     }
 
     await loadingPending.wrap(this.props.getPending())
+    await loadingFriendRequests.wrap(this.props.getFriendRequests())
     await loadingRecentTransactions.wrap(this.props.getRecentTransactions())
     await loadingFriends.wrap(this.props.getFriends())
     await loadingPayPalRequests.wrap(this.props.getPayPalRequests())
@@ -258,4 +261,4 @@ export default connect((state) => ({ state: getStore(state)(), user: getUser(sta
   needsReviewCount: getNeedsReviewCount(state), calculateBalance: calculateBalance(state), calculateCounterparties: calculateCounterparties(state),
   primaryCurrency: getPrimaryCurrency(state), friendList: getFriendList(state)(), getPendingFromFriend: getPendingFromFriend(state),
   ethExchange: getEthExchange(state), getFriendFromNick: getFriendFromNick(state) }), 
-  { getAccountInformation, displayError, getPending, getPayPalRequests, getRecentTransactions, getFriends, registerChannelID })(HomeView)
+  { getAccountInformation, displayError, getPending, getPayPalRequests, getRecentTransactions, getFriends, registerChannelID, getFriendRequests })(HomeView)


### PR DESCRIPTION
1. Problem: friend requests were not showing up due to a recent change. Avatar issues on AddFriendRow in SearchFriend
2. Solution: Add the getFriendRequests call to the home screen and get the avatar on SearchFriend
3. No concerns
4. No blockers