### PR TITLE
ENG-157: re-ordered text and buttons on welcome screen 4

### DIFF
--- a/packages/ui/views/welcome/welcome-step-four/index.tsx
+++ b/packages/ui/views/welcome/welcome-step-four/index.tsx
@@ -23,10 +23,10 @@ export default class WelcomeStepFourView extends Component<Props> {
       <ScrollView>
         <View style={style.topView}>
           <TextLogo name='black'/>
-          <Text style={[style.text, style.topSpacing]}>{welcomeView.firstLendingApp}</Text>
-          <ThemeImage size={largeImage} name='blockchain'/>
-          <Text style={[style.caption, style.boldCaption]}>{welcomeView.runEthereum}</Text>
+          <Text style={[style.caption, style.boldCaption, style.topSpacing]}>{welcomeView.runEthereum}</Text>
           <Button large round wide onPress={this.props.onComplete} containerStyle={style.completeButton} text={welcomeView.start} />
+          <Text style={[style.text]}>{welcomeView.firstLendingApp}</Text>
+          <ThemeImage size={largeImage} name='blockchain'/>
         </View>
       </ScrollView>
     )


### PR DESCRIPTION
The "Get Started" button was getting cut-off under some circumstances, this update guarantees that won't happen.