### PR TITLE
Fix duplicate child warning

### DIFF
--- a/packages/ui/views/account/activity/pending/index.tsx
+++ b/packages/ui/views/account/activity/pending/index.tsx
@@ -178,10 +178,11 @@ class PendingView extends Component<Props, State> {
             if(homeScreen && payPalRequest.requestorIsMe) {
               return null
             }
+            const uniquifier = (payPalRequest.requestorIsMe) ? 'm' : ''
             return <PayPalRequestRow
               payPalRequest={payPalRequest}
               navigation={navigation}
-              key={payPalRequest.friend.address}
+              key={`${uniquifier}${payPalRequest.friend.address}`}
             />
           })
         }

--- a/packages/ui/views/welcome/welcome-step-four/index.tsx
+++ b/packages/ui/views/welcome/welcome-step-four/index.tsx
@@ -23,10 +23,10 @@ export default class WelcomeStepFourView extends Component<Props> {
       <ScrollView>
         <View style={style.topView}>
           <TextLogo name='black'/>
-          <Text style={[style.text, style.topSpacing]}>{welcomeView.firstLendingApp}</Text>
-          <ThemeImage size={largeImage} name='blockchain'/>
-          <Text style={[style.caption, style.boldCaption]}>{welcomeView.runEthereum}</Text>
+          <Text style={[style.caption, style.boldCaption, style.topSpacing]}>{welcomeView.runEthereum}</Text>
           <Button large round wide onPress={this.props.onComplete} containerStyle={style.completeButton} text={welcomeView.start} />
+          <Text style={[style.text]}>{welcomeView.firstLendingApp}</Text>
+          <ThemeImage size={largeImage} name='blockchain'/>
         </View>
       </ScrollView>
     )


### PR DESCRIPTION
A simple hack to eliminate the duplicate child warning, PayPal requests can be either "from" me or "to" me, so we add something to the key to represent this directionality. This eliminates the warning.