### PR TITLE
Added outbound friend requests

### DIFF
--- a/packages/actions/index.ts
+++ b/packages/actions/index.ts
@@ -467,8 +467,6 @@ export const getFriendRequests = () => {
     const rawPendingOutboundFriends = await creditProtocol.getOutboundFriendRequests(user.address)
     const pendingOutboundFriends = rawPendingOutboundFriends.map(jsonToPendingFriend)
 
-    console.log('THIS IS IT ', pendingFriends, pendingOutboundFriends)
-  
     dispatch(setState({ pendingFriends, pendingOutboundFriends, pendingFriendsLoaded: true }))
   }
 }

--- a/packages/actions/index.ts
+++ b/packages/actions/index.ts
@@ -463,8 +463,13 @@ export const getFriendRequests = () => {
     const user = getUser(getState())()
     const rawPendingFriends = await creditProtocol.getFriendRequests(user.address)
     const pendingFriends = rawPendingFriends.map(jsonToPendingFriend)
+
+    const rawPendingOutboundFriends = await creditProtocol.getOutboundFriendRequests(user.address)
+    const pendingOutboundFriends = rawPendingOutboundFriends.map(jsonToPendingFriend)
+
+    console.log('THIS IS IT ', pendingFriends, pendingOutboundFriends)
   
-    dispatch(setState({ pendingFriends, pendingFriendsLoaded: true }))
+    dispatch(setState({ pendingFriends, pendingOutboundFriends, pendingFriendsLoaded: true }))
   }
 }
 

--- a/packages/credit-protocol/index.ts
+++ b/packages/credit-protocol/index.ts
@@ -238,6 +238,10 @@ export default class CreditProtocol {
     return this.cacheHttpRequest(`/friend_requests/${user}`, 5000)
   }
 
+  getOutboundFriendRequests(user: string) {
+    return this.cacheHttpRequest(`/outbound_friend_requests/${user}`, 5000)
+  }
+
   getPendingTransactions(user: string) {
     return this.cacheHttpRequest(`/pending/${user}`, 1000)
   }

--- a/packages/language/languages/ar.ts
+++ b/packages/language/languages/ar.ts
@@ -368,6 +368,10 @@ export default {
       start: `لقد رفضت طلب الصداقة من `,
       end: `.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `لقد ألغت صديق طلب `,
+      end: `.`,
+    },
     ethSent: {
       start: `لقد أرسلت `,
       end: ` إثيريوم بنجاح ورقم الهاش لمعاملتك هو `,
@@ -396,6 +400,7 @@ export default {
     shell: `طلب صداقة`,
     message: `طلبات الصداقة`,
     request: F => `@${F} يريد أن يصبح صديقاً معك!`,
+    outbound: F => `أنت أرسلت طلب صداقة إلى @${F}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/cs.ts
+++ b/packages/language/languages/cs.ts
@@ -368,6 +368,10 @@ export default {
       start: `Odmítli jste žádost o přátelství od `,
       end: `a.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Zrušili jste žádost o přátelství na `,
+      end: `.`,
+    },
     ethSent: {
       start: `Úspěšně jste odeslal(a) `,
       end: ` ETH a hash vaší transakce je `,
@@ -396,6 +400,7 @@ export default {
     shell: `Žádost o přátelství`,
     message: `Žádosti o přátelství`,
     request: F => `@${F} si vás chce přidat mezi přátele!`,
+    outbound: F => `jste poslal žádost o přátelství na @${F}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/da.ts
+++ b/packages/language/languages/da.ts
@@ -368,6 +368,10 @@ export default {
       start: `Du har afvist venneanmodningen fra `,
       end: `.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Du har annulleret venneanmodning til `,
+      end: `.`,
+    },
     ethSent: {
       start: `Du har nu sendt `,
       end: ` ETH og dit transaktion ID er `,
@@ -396,6 +400,7 @@ export default {
     shell: `Venneanmodning`,
     message: `Venneanmodninger`,
     request: F => `@${F} ønsker at være venner med dig!`,
+    outbound: F => `Du sendt en venneanmodning til @${F}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/de.ts
+++ b/packages/language/languages/de.ts
@@ -371,6 +371,10 @@ export default {
       start: `Sie haben die Freundschaftsanfrage von `,
       end: ` abgelehnt.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Sie haben die Freundschaftsanfrag abgesagt `,
+      end: `.`,
+    },
     ethSent: {
       start: `Sie haben erfolgreich `,
       end: ` ETH gesendet und Ihre Transaktion-Hash ist `,
@@ -399,6 +403,7 @@ export default {
     shell: `Freundschaftsanfrage`,
     message: `Freundschaftsanfragen`,
     request: F => `@${F} möchte mit Ihnen befreundet sein!`,
+    outbound: F => `Sie schickte einen Freund Anfrage an @${F}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/el.ts
+++ b/packages/language/languages/el.ts
@@ -368,6 +368,10 @@ export default {
       start: `Έχετε απορρίψει το αίτημα φιλίας του `,
       end: `.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Έχετε ακυρώσει το αίτημα φιλίας σε `,
+      end: `.`,
+    },
     ethSent: {
       start: `Έχετε στείλει με επιτυχία `,
       end: ` ETH και το hash της συναλλαγής σας είναι `,
@@ -396,6 +400,7 @@ export default {
     shell: `Αίτημα Φιλίας`,
     message: `Αιτήματα φιλίας`,
     request: F => `Ο/Η @${F} θέλει να γίνετε φίλοι!`,
+    outbound: F => `Έχετε στείλει ένα αίτημα φιλίας σε @${F}`
   },
 
   privacyPolicy: {

--- a/packages/language/languages/en.ts
+++ b/packages/language/languages/en.ts
@@ -365,6 +365,10 @@ export default {
       start: `You have declined the friend request from `,
       end: `.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `You have cancelled the friend request to `,
+      end: `.`,
+    },
     ethSent: {
       start: `You have successfully sent `,
       end: ` ETH and your transaction hash is `,
@@ -393,6 +397,7 @@ export default {
     shell: `Friend Request`,
     message: `Friend Requests`,
     request: friend => `@${friend} wants to be friends with you!`,
+    outbound: friend => `You sent a friend request to @${friend}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/es.ts
+++ b/packages/language/languages/es.ts
@@ -368,6 +368,10 @@ export default {
       start: `Ha rechazado la solicitud de amistad de `,
       end: `.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Ha cancelado la solicitud de amistad a `,
+      end: `.`,
+    },
     ethSent: {
       start: `Ha enviado `,
       end: ` ETH con éxito, y el hash de la transacción es `,
@@ -396,6 +400,7 @@ export default {
     shell: `Solicitud de amistad`,
     message: `Solicitudes de amistad`,
     request: F => `@${F} quiere ser su Amigo!`,
+    outbound: F => `Se envió una solicitud de amistad a @${F}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/fi.ts
+++ b/packages/language/languages/fi.ts
@@ -368,6 +368,10 @@ export default {
       start: `Olet hylännyt `,
       end: ` ystäväpyynnön.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Olet peruuttanut ystävä pyynnön `,
+      end: `.`,
+    },
     ethSent: {
       start: `Olet onnistuneesti lähettänyt `,
       end: ` ETH:ta ja tapahtumasi tunnusnumero on `,
@@ -396,6 +400,7 @@ export default {
     shell: `Ystäväpyyntö`,
     message: `Ystäväpyynnöt`,
     request: F => `@${F} haluaa olla ystäväsi! `,
+    outbound: F => `Olet lähettänyt ystävä pyynnön @${F}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/fr.ts
+++ b/packages/language/languages/fr.ts
@@ -368,6 +368,10 @@ export default {
       start: `Vous avez refusé la demande d'ami de `,
       end: `.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Vous avez annulé la demande d'ami à `,
+      end: `.`,
+    },
     ethSent: {
       start: `Vous avez envoyé avec succès `,
       end: ` ETH et le hachage de votre transaction est `,
@@ -396,6 +400,7 @@ export default {
     shell: `Demande d'ami`,
     message: `Demandes d'ami`,
     request: F => `@${F} veut être ami avec vous !`,
+    outbound: F => `Vous a envoyé une demande d'ami à @${F}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/hi.ts
+++ b/packages/language/languages/hi.ts
@@ -368,6 +368,10 @@ export default {
       start: `आपने `,
       end: ` की फ्रेंड रिक्वेस्ट अस्वीकार दी है।`,
     },
+    rejectOutboundFriendRequest: {
+      start: `आप `,
+      end: ` को मित्र अनुरोध रद्द कर दिया है.`,
+    },
     ethSent: {
       start: `आपने `,
       end: ` ETH भेज दिये हैं और आपका ट्रैंज़ैक्शन हैश `,
@@ -396,6 +400,7 @@ export default {
     shell: `फ्रेंड रिक्वेस्ट`,
     message: `फ्रेंड रिक्वेस्ट्स`,
     request: F => `@${F} आपका फ्रेंड बनना चाहता/चाहती है!`,
+    outbound: F => `आप @${F} को मित्र अनुरोध भेजा`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/hu.ts
+++ b/packages/language/languages/hu.ts
@@ -368,6 +368,10 @@ export default {
       start: `Elutasította `,
       end: ` ismerősnek jelölését.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Megszakította a barátja kérését `,
+      end: `.`,
+    },
     ethSent: {
       start: `Sikeresen elküldött `,
       end: ` ETH-t, és a tranzakciós hash `,
@@ -396,6 +400,7 @@ export default {
     shell: `Ismerősnek Jelölés`,
     message: `Ismerősnek Jelölések`,
     request: F => `@${F} szeretne az ismerőse lenni! `,
+    outbound: F => `A kérelmet küldött a @${F} `,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/in.ts
+++ b/packages/language/languages/in.ts
@@ -368,6 +368,10 @@ export default {
       start: `Anda menolak permintaan pertemanan dari `,
       end: `.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Anda telah membatalkan permintaan teman untuk `,
+      end: `.`,
+    },
     ethSent: {
       start: `Anda berhasil mengirimkan `,
       end: ` ETH, dan hash transaksi Anda adalah `,
@@ -396,6 +400,7 @@ export default {
     shell: `Permintaan Pertemanan`,
     message: `Permintaan Pertemanan`,
     request: F => `@${F} ingin berteman dengan Anda!`,
+    outbound: F => `Anda mengirim permintaan teman untuk @${F}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/it.ts
+++ b/packages/language/languages/it.ts
@@ -368,6 +368,10 @@ export default {
       start: `Hai rifiutato la richiesta di amicizia da `,
       end: `.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Hai annullato la richiesta di amicizia di `,
+      end: `.`,
+    },
     ethSent: {
       start: `Hai inviato con successo `,
       end: ` ETH e l'hash per la transazione è `,
@@ -396,6 +400,7 @@ export default {
     shell: `Richiesta di amicizia`,
     message: `Richieste di amicizia`,
     request: F => `@${F} vuole essere tuo amico!`,
+    outbound: F => `È inviato una richiesta di amicizia a @${F}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/iw.ts
+++ b/packages/language/languages/iw.ts
@@ -368,6 +368,10 @@ export default {
       start: `דחית את בקשת החברות מ   `,
       end: `.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `ביטלת את בקשת חברות ל `,
+      end: `.`,
+    },
     ethSent: {
       start: `שלחת ETH `,
       end: ` בהצלחה ומספר העסקה שלך הוא`,
@@ -396,6 +400,7 @@ export default {
     shell: `בקשת חברות`,
     message: `בקשות חברות`,
     request: F => `!רוצה להיות חבר שלך @${F}`,
+    outbound: F => `שלח בקשת חברות ל @${F}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/ja.ts
+++ b/packages/language/languages/ja.ts
@@ -357,6 +357,18 @@ export default {
       start: ``,
       end: ` に通知を送ります.`,
     },
+    confirmFriend: {
+      start: `これで`,
+      end: `と友達です!`,
+    },
+    rejectFriend: {
+      start: `あなたは`,
+      end: `からの友達リクエストを拒否してきました.`,
+    },
+    rejectOutboundFriendRequest: {
+      start: `あなたは `,
+      end: ` に友達リクエストをキャンセルしました.`,
+    },
     ethSent: {
       start: `送信成功 `,
       end: ` あなたのETHとトランザクションハッシュは `,
@@ -384,7 +396,8 @@ export default {
   pendingFriendRequestsLanguage: {
     shell: `友達リクエスト`,
     message: `友達リクエスト`,
-    request: F => `@${F}はあなたと友達になりたい！`
+    request: F => `@${F}はあなたと友達になりたい！`,
+    outbound: F => `あなたは @${F}に友達リクエストを送信し`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/ko.ts
+++ b/packages/language/languages/ko.ts
@@ -357,6 +357,18 @@ export default {
       start: "우리는 ",
       end: " 해당 기록을 당신이 거부한것을 전달했습니다."
     },
+    confirmFriend: {
+      start: `이제 `,
+      end: ` 와 친구!`,
+    },
+    rejectFriend: {
+      start: `당신은`,
+      end: `에서 친구 요청을 거절했다.`,
+    },
+    rejectOutboundFriendRequest: {
+      start: `당신은 `,
+      end: ` 하는 친구 요청을 취소.`,
+    },
     ethSent: {
       start: "성공적으로 보냈습니다 ",
       end: " 이더리움과 당신의 거래는 "
@@ -384,7 +396,8 @@ export default {
   pendingFriendRequestsLanguage: {
     shell: `친구 요청`,
     message: `친구 요청`,
-    request: F => `@${F}이 너와 친구가되고 싶어！`
+    request: F => `@${F}이 너와 친구가되고 싶어！`,
+    outbound: F => `당신은@${F}에 친구 요청을 보내`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/ms.ts
+++ b/packages/language/languages/ms.ts
@@ -368,6 +368,10 @@ export default {
       start: `Anda telah menolak permintaan `,
       end: ` untuk menjadi rakan.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Anda telah membatalkan permintaan rakan untuk `,
+      end: `.`,
+    },
     ethSent: {
       start: `Anda telah berjaya menghantar `,
       end: ` ETH dan cincangan transaksi anda adalah `,
@@ -396,6 +400,7 @@ export default {
     shell: `Permintaan jadi rakan`,
     message: `Permintaan jadi rakan`,
     request: F => `@${F} mahu menjadi rakan anda!`,
+    outbound: F => `Anda menghantar permintaan rakan kepada @${F} `,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/nb.ts
+++ b/packages/language/languages/nb.ts
@@ -368,6 +368,10 @@ export default {
       start: `Du har avvist venneforespørselen fra `,
       end: `.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Du har avbrutt venneforespørsel til `,
+      end: `.`,
+    },
     ethSent: {
       start: `Du har sendt `,
       end: ` ETH og transaksjonens referanse er `,
@@ -396,6 +400,7 @@ export default {
     shell: `Venneforespørsel`,
     message: `Venneforespørsler`,
     request: F => `@${F} ønsker å være venner med deg!`,
+    outbound: F => `Du sendt en forespørsel om å venn @${F}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/nl.ts
+++ b/packages/language/languages/nl.ts
@@ -368,6 +368,10 @@ export default {
       start: `U heeft de vriendschapsaanvraag van `,
       end: ` geweigerd.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `U heeft de aanvraag voor een vriend te `,
+      end: ` geannuleerd.`,
+    },
     ethSent: {
       start: `U heeft succesvol `,
       end: ` ETH verzonden en uw transactiekenmerk is `,
@@ -396,6 +400,7 @@ export default {
     shell: `Vriendschapsverzoek`,
     message: `Vriendschapsverzoeken`,
     request: F => `@${F} wil vrienden met u worden! `,
+    outbound: F => `Je stuurde een vriend verzoek aan @${F} `,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/no.ts
+++ b/packages/language/languages/no.ts
@@ -368,6 +368,10 @@ export default {
       start: `Du har avvist venneforespørselen fra `,
       end: `.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Du har avbrutt venneforespørsel til `,
+      end: `.`,
+    },
     ethSent: {
       start: `Du har sendt `,
       end: ` ETH og transaksjonens referanse er `,
@@ -396,6 +400,7 @@ export default {
     shell: `Venneforespørsel`,
     message: `Venneforespørsler`,
     request: F => `@${F} ønsker å være venner med deg!`,
+    outbound: F => `Du sendt en forespørsel om å venn @${F}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/pl.ts
+++ b/packages/language/languages/pl.ts
@@ -368,6 +368,10 @@ export default {
       start: `Odrzuciłeś/odrzuciłaś zaproszenie od `,
       end: `.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Masz odwołał zaproszenie do `,
+      end: `.`,
+    },
     ethSent: {
       start: `Udało się wysłać `,
       end: ` ETH, hash dla tej transakcji to `,
@@ -396,6 +400,7 @@ export default {
     shell: `Prośba o Przyjęcie do grona Znajomych`,
     message: `Prośby o Przyjęcie do grona Znajomych`,
     request: F => `@${F} chce być Twoim znajomym!`,
+    outbound: F => `Ty wysłał zaproszenie do @${F}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/pt.ts
+++ b/packages/language/languages/pt.ts
@@ -368,6 +368,10 @@ export default {
       start: `Você recusou o pedido de amizade de `,
       end: `.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Você cancelou a solicitação de amigo para `,
+      end: `.`,
+    },
     ethSent: {
       start: `Você enviou com sucesso `,
       end: ` ETH e seu hash de transação é `,
@@ -396,6 +400,7 @@ export default {
     shell: `Pedido de amizade`,
     message: `Pedidos de amizade`,
     request: F => `@${F} quer ser seu amigo!`,
+    outbound: F => `Você enviou uma solicitação de amigo para @${F}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/ru.ts
+++ b/packages/language/languages/ru.ts
@@ -368,6 +368,10 @@ export default {
       start: `Вы отклонили запрос друга от `,
       end: `а.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Вы отменили запрос друга в `,
+      end: `.`,
+    },
     ethSent: {
       start: `Вы успешно отправили `,
       end: ` ETH, а хеш транзакции `,
@@ -396,6 +400,7 @@ export default {
     shell: `Запрос в друзья`,
     message: `Запросы в друзья`,
     request: F => `@${F} хочет с вами дружить!`,
+    outbound: F => `Вы послали запрос друга на @${F} `,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/sv.ts
+++ b/packages/language/languages/sv.ts
@@ -368,6 +368,10 @@ export default {
       start: `Du har avböjt vänförfrågan från `,
       end: `.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Du har avbrutit vänförfrågan till `,
+      end: `.`,
+    },
     ethSent: {
       start: `Du har framgångsrikt skickat `,
       end: ` ETH och din transaktionshash är `,
@@ -396,6 +400,7 @@ export default {
     shell: `Vänförfrågan`,
     message: `Vänförfrågningar`,
     request: F => `@${F} vill vara vän med dig!`,
+    outbound: F => `Du skickade en vänförfrågan till @${F} `,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/th.ts
+++ b/packages/language/languages/th.ts
@@ -368,6 +368,10 @@ export default {
       start: `คุณได้ปฏิเสธคำขอเป็นเพื่อนจาก`,
       end: `.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `คุณได้ยกเลิกคำขอเป็นเพื่อนเพื่อ `,
+      end: `.`,
+    },
     ethSent: {
       start: `คุณได้ส่ง `,
       end: ` ETH เรียบร้อยแล้ว และแฮชธุรกรรมของคุณคือ `,
@@ -396,6 +400,7 @@ export default {
     shell: `คำขอเป็นเพื่อน`,
     message: `คำขอเป็นเพื่อน`,
     request: F => `@${F} อยากเป็นเพื่อนกับคุณ!`,
+    outbound: F => `คุณส่งคำขอเป็นเพื่อนเพื่อ @${F}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/tr.ts
+++ b/packages/language/languages/tr.ts
@@ -368,6 +368,10 @@ export default {
       start: ``,
       end: `’dan gelen arkadaşlık isteğini reddettiniz.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Sen `,
+      end: ` Arkadaş isteğini iptal.`,
+    },
     ethSent: {
       start: `Başarıyla `,
       end: ` ETH gönderdiniz ve işlem sağlama kodunuz `,
@@ -396,6 +400,7 @@ export default {
     shell: `Arkadaşlık isteği`,
     message: `Arkadaş istekleri`,
     request: F => `@${F} seninle arkadaş olmak istiyor!`,
+    outbound: F => `Sen @${F} için arkadaşlık isteği gönderdi`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/vi.ts
+++ b/packages/language/languages/vi.ts
@@ -368,6 +368,10 @@ export default {
       start: `Bạn đã từ chối yêu cầu kết bạn từ `,
       end: `.`,
     },
+    rejectOutboundFriendRequest: {
+      start: `Bạn đã hủy bỏ yêu cầu kết bạn đến `,
+      end: `.`,
+    },
     ethSent: {
       start: `Bạn đã gửi thành công `,
       end: ` ETH và mã hóa giao dịch của bạn là `,
@@ -396,6 +400,7 @@ export default {
     shell: `Yêu cầu kết bạn`,
     message: `Yêu cầu kết bạn`,
     request: F => `@${F} muốn kết bạn với bạn!`,
+    outbound: F => `Bạn đã gửi yêu cầu kết bạn đến @${F}`,
   },
 
   privacyPolicy: {

--- a/packages/language/languages/zh-CN.ts
+++ b/packages/language/languages/zh-CN.ts
@@ -368,6 +368,10 @@ export default {
       start: `您拒绝好友的要求`,
       end: `。`,
     },
+    rejectOutboundFriendRequest: {
+      start: `您已取消好友请求为 `,
+      end: `.`,
+    },
     ethSent: {
       start: `您发送`,
       end: `ETH和您的交易记录号是：`,
@@ -395,7 +399,8 @@ export default {
   pendingFriendRequestsLanguage: {
     shell: `请求好友`,
     message: `请求好友`,
-    request: F => `@${F}愿意跟你做好友！`
+    request: F => `@${F}愿意跟你做好友！`,
+    outbound: F =>`你发送好友请求，以@${F}`,
   },
 
   privacyPolicy: {

--- a/packages/ui/components/pending-friend-row/index.tsx
+++ b/packages/ui/components/pending-friend-row/index.tsx
@@ -17,6 +17,11 @@ let unmounting = false;
 interface Props {
   friend: Friend
   navigation: any
+  isOutbound?: boolean
+}
+
+interface PassedProps extends React.Props<any> {
+  isOutbound?: boolean
 }
 
 interface State {
@@ -47,17 +52,18 @@ export default class PendingFriendRow extends Component<Props, State> {
   }
 
   render() {
-    const { friend, navigation } = this.props
+    const { friend, navigation, isOutbound } = this.props
     const { pic } = this.state
     const imageSource = pic ? { uri: pic } : require('images/person-outline-dark.png')
+    const message = isOutbound ? pendingFriendRequestsLanguage.outbound : pendingFriendRequestsLanguage.request
 
     return (
-      <TouchableHighlight style={style.friendRow} onPress={() => navigation.navigate('FriendRequest', { friend })} underlayColor={white} activeOpacity={1}>
+      <TouchableHighlight style={style.friendRow} onPress={() => navigation.navigate('FriendRequest', { friend, isOutbound })} underlayColor={white} activeOpacity={1}>
         <View style={style.pendingTransactionRow}>
           <View style={[general.flexRow, general.alignCenter]}>
             <Image source={imageSource} style={style.friendIcon}/>
             <View style={general.flexColumn}>
-              <Text style={style.friendRequest}>{pendingFriendRequestsLanguage.request(friend.nickname)}</Text>
+              <Text style={style.friendRequest}>{message(friend.nickname)}</Text>
             </View>
           </View>
         </View>

--- a/packages/ui/dialogs/confirmation-screen/index.tsx
+++ b/packages/ui/dialogs/confirmation-screen/index.tsx
@@ -19,7 +19,7 @@ interface Props {
 export default class ConfirmationScreen extends Component<Props> {
   getConfirmationImage(type) {
     const acceptList = ['create', 'confirm', 'ethSent', 'bcptSent', 'confirmFriend', 'requestPayPalPayee', 'requestPayPalPayment', 'settledWithPayPal']
-    const rejectList = ['reject', 'rejectFriend']
+    const rejectList = ['reject', 'rejectFriend', 'rejectOutboundFriendRequest']
     if (acceptList.indexOf(type) >= 0) {
       return <Image source={require('images/check-circle.png')} style={style.image} />
     } else if (rejectList.indexOf(type) >= 0) {

--- a/packages/ui/views/account/activity/pending/index.tsx
+++ b/packages/ui/views/account/activity/pending/index.tsx
@@ -84,7 +84,7 @@ class PendingView extends Component<Props, State> {
   }
 
   showNoneMessage() {
-    const { pendingTransactionsLoaded, pendingTransactions, pendingSettlements, bilateralSettlements, pendingFriends, payPalRequests } = this.props.state
+    const { pendingTransactionsLoaded, pendingTransactions, pendingSettlements, bilateralSettlements, pendingFriends, pendingOutboundFriends, payPalRequests } = this.props.state
     const { friend } = this.props
 
     let showNone = false
@@ -95,6 +95,7 @@ class PendingView extends Component<Props, State> {
       showNone = (pendingTransactions.length
         + pendingSettlements.length
         + pendingFriends.length
+        + pendingOutboundFriends.length
         + payPalRequests.length) === 0
     } else if (friend) {
       showNone = true
@@ -123,7 +124,7 @@ class PendingView extends Component<Props, State> {
   }
 
   render() {
-    const { pendingTransactions, pendingFriends } = this.props.state
+    const { pendingTransactions, pendingFriends, pendingOutboundFriends } = this.props.state
     const { pendingSettlements, settlerIsMe, payPalRequests, bilateralSettlements, user, friend, homeScreen, onlyFriends, navigation } = this.props
 
     if (onlyFriends) {
@@ -212,13 +213,23 @@ class PendingView extends Component<Props, State> {
             />
           })
         }
-        { homeScreen || pendingFriends.length === 0 ? null : <Text style={style.transactionHeader}>{pendingFriendRequestsLanguage.message}</Text>}
+        { homeScreen || !pendingFriends.length ? null : <Text style={style.transactionHeader}>{pendingFriendRequestsLanguage.message}</Text>}
         { pendingFriends.length === 0 ? null :
           pendingFriends.map( friend => {
             return <PendingFriendRow
               key={friend.address}
               friend={friend}
               navigation={this.props.navigation}
+            />
+          })
+        }
+        { homeScreen || !pendingOutboundFriends.length ? null :
+          pendingOutboundFriends.map( friend => {
+            return <PendingFriendRow
+              key={friend.address}
+              friend={friend}
+              navigation={this.props.navigation}
+              isOutbound
             />
           })
         }

--- a/packages/ui/views/account/friends/index.tsx
+++ b/packages/ui/views/account/friends/index.tsx
@@ -125,9 +125,9 @@ class FriendsView extends Component<Props, State> {
 
     let friendListTitle: JSX.Element[] = []
     if (pendingFriends && pendingFriends.length > 0)
-      friendListTitle.push(<Text style={style.transactionHeader}>{currentFriends}</Text>)
+      friendListTitle.push(<Text key='pendingFriendsTitle' style={style.transactionHeader}>{currentFriends}</Text>)
     if (friendsLoaded && friends.length === 0)
-      friendListTitle.push(<Text style={style.emptyState}>{noFriends}</Text>)
+      friendListTitle.push(<Text key='noFriendsTitle' style={style.emptyState}>{noFriends}</Text>)
 
     return <ScrollView style={general.view} keyboardShouldPersistTaps='handled' ref='_friendScrollView'
       refreshControl={

--- a/packages/ui/views/app/index.tsx
+++ b/packages/ui/views/app/index.tsx
@@ -50,6 +50,7 @@ const initialState = {
   pendingTransactions: [],
   pendingSettlements: [],
   pendingFriends: [],
+  pendingOutboundFriends: [],
   bilateralSettlements: [],
   notificationsEnabled: true,
   ethBalance: '0',


### PR DESCRIPTION
 1. Problem: Lndr only has inbound friend requests that are FOR the user, we want to also show requests that are FROM the user and allow the user to delete them. https://blockmason.atlassian.net/secure/RapidBoard.jspa?rapidView=9&projectKey=ENG&selectedIssue=ENG-94
 2. Solution: The server will add an endpoint `/outbound_friend_requests` and these will be displayed in the pending section of the UI
 3. Main trade-off: to avoid breaking changes, the app will get an additional list of pending requests rather than modify the current `friend_requests` endpoint
 4. Blocker: need to have the server update deployed before this will work