### PR TITLE
Eth fiat format

### DIFF
--- a/__tests__/lndr/format.ts
+++ b/__tests__/lndr/format.ts
@@ -25,6 +25,7 @@ describe('amountFormat', () => {
 describe('formatEthToFiat', () => {
   it('Formats an ETH amount correctly', () => {
     expect(formatEthToFiat('2', '100.10', 'USD')).toBe(` (US$200.20)`)
+    expect(formatEthToFiat('2', '100.10121242', 'USD')).toBe(` (US$200.20)`)
   })
 })
 

--- a/packages/lndr/format/index.ts
+++ b/packages/lndr/format/index.ts
@@ -203,6 +203,17 @@ export const convertCommaDecimalToPoint = (amount: string) : string => {
 
 export const formatEthToFiat = (ethBalance: string, ethExchange: string, currency: string) : string => {
   let converted = String( Number(ethBalance) * Number(ethExchange) ).slice(0, 8)
+  if(hasNoDecimals(currency)) {
+    converted = converted.slice(0, converted.indexOf('.'))
+  }
+  let decimal = converted.indexOf('.')
+  if(isCommaDecimal()) {
+    converted = converted.replace('.', ',')
+    decimal = converted.indexOf(',')
+  }
+  if(decimal !== -1) {
+    converted = converted.slice(0, decimal + 2)
+  }
   return ` (${amountFormat(converted, currency, true)})`
 }
 

--- a/packages/lndr/format/index.ts
+++ b/packages/lndr/format/index.ts
@@ -203,13 +203,7 @@ export const convertCommaDecimalToPoint = (amount: string) : string => {
 
 export const formatEthToFiat = (ethBalance: string, ethExchange: string, currency: string) : string => {
   let converted = String( Number(ethBalance) * Number(ethExchange) ).slice(0, 8)
-  if(converted.slice(-2, -1) === '.') {
-    converted = converted + '0'
-  } else if(converted.slice(-1) === '.') {
-    converted = converted.slice(-1)
-  }
-  
-  return ` (${currencySymbols(currency)}${isCommaDecimal() ? converted.replace('.', ',') : converted})`
+  return ` (${amountFormat(converted, currency, true)})`
 }
 
 export const formatCommaDecimal = (amount: string) : string => isCommaDecimal() ? amount.replace('.', ',') : amount


### PR DESCRIPTION
 1. Jira: https://blockmason.atlassian.net/secure/RapidBoard.jspa?rapidView=9&projectKey=ENG&selectedIssue=ENG-186
 2. Problem: The conversion from Eth to fiat on the Home screen and MyAccount screen was showing more than 2 decimals places
 3. Solution: Update the formatting function to show 0 or 2 decimals (depending on the currency)
 4. No concerns or tradeoffs, this was very straight-forward
 5. No blockers
