### PR TITLE
Fixed fingerprint auth failure

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -177,6 +177,7 @@ dependencies {
         force = true;
     }
     compile 'com.paypal.sdk:paypal-android-sdk:2.16.0'
+    compile 'com.google.firebase:firebase-analytics'
 }
 
 // Run this once to be able to run the application with BUCK

--- a/android/app/src/main/java/com/lndr/MainApplication.java
+++ b/android/app/src/main/java/com/lndr/MainApplication.java
@@ -5,6 +5,7 @@ import android.app.Application;
 import com.facebook.react.ReactApplication;
 import org.devio.rn.splashscreen.SplashScreenReactPackage;
 import io.invertase.firebase.RNFirebasePackage;
+import io.invertase.firebase.analytics.RNFirebaseAnalyticsPackage;
 import com.imagepicker.ImagePickerPackage;
 import com.rnfingerprint.FingerprintAuthPackage;
 import com.urbanairship.reactnative.ReactAirshipPackage;
@@ -46,7 +47,8 @@ public class MainApplication extends Application implements ReactApplication {
             new RNFetchBlobPackage(),
             new ImageResizerPackage(),
             new PayPalPackage(),
-            new LocalizationPackage()
+            new LocalizationPackage(),
+            new RNFirebaseAnalyticsPackage()
       );
     }
 

--- a/packages/actions/util.ts
+++ b/packages/actions/util.ts
@@ -21,7 +21,7 @@ export const triggerTouchId = (user, notificationsEnabled, sessionStorage) => {
     return { hasStoredUser: true, welcomeComplete: true, privacyPolicyVerified: true, notificationsEnabled, user }
   })
   .catch(_error => {
-    return { hasStoredUser: true, welcomeComplete: true, privacyPolicyVerified: true, notificationsEnabled }
+    return { hasStoredUser: true, welcomeComplete: true, privacyPolicyVerified: true, notificationsEnabled, user: undefined }
   })
 }
 


### PR DESCRIPTION
 1. Jira: https://blockmason.atlassian.net/secure/RapidBoard.jspa?rapidView=9&projectKey=ENG&selectedIssue=ENG-187
 2. Problem: When the user has fingerprint auth enabled and leaves the app running in the background, when they come back to the app, they are asked to use their fingerprint to unlock. If they click 'Cancel' they are still allowed into the app.
 3. Solution: If the user clicks 'Cancel' from the fingerprint auth alert, delete the stored user object, which will bring up the PIN auth screen.
 4. No concerns
 5. No blockers