### PR TITLE
Hotfix for BCPT/Eth wallet address include '0x'

### DIFF
--- a/packages/ui/dialogs/my-account/index.tsx
+++ b/packages/ui/dialogs/my-account/index.tsx
@@ -380,12 +380,13 @@ class MyAccount extends Component<Props, State> {
       await loadingContext.wrap(updateEmail(this.state))
     }
 
+    const hexAddress = `0x${user.address}`
     const panelContent = [
       (<View style={style.spaceHorizontalL}>
         <Text style={[style.text, style.spaceTopL, style.center]}>{addressExhortation}</Text>
         <Text style={[style.smallText, style.spaceTop, style.center]}>{accountManagement.sendEth.note(currency, transferLimitLevel())}</Text>
-        <Text selectable style={style.displayText}>{`0x${user.address}`}</Text>
-        <Button round onPress={() => copyToClipboard(user.address)} text={copy} />
+        <Text selectable style={style.displayText}>{hexAddress}</Text>
+        <Button round onPress={() => copyToClipboard(hexAddress)} text={copy} />
       </View>),
       (<View style={style.spaceHorizontalL}>
         <Text style={[style.text, style.spaceTopL, style.center]}>{currentBalance.eth}</Text>

--- a/packages/ui/dialogs/transfer-bcpt/index.tsx
+++ b/packages/ui/dialogs/transfer-bcpt/index.tsx
@@ -6,7 +6,7 @@ import firebase from 'react-native-firebase'
 import { getResetAction } from 'reducers/nav'
 
 import { UserData } from 'lndr/user'
-import { bcptAmount, ethAddress, formatCommaDecimal } from 'lndr/format'
+import { bcptAmount, formatCommaDecimal, isEthAddress } from 'lndr/format'
 
 import Button from 'ui/components/button'
 import Loading, { LoadingContext } from 'ui/components/loading'
@@ -64,7 +64,7 @@ class TransferBcpt extends Component<Props, State> {
   async submit() {
     const { amount, address } = this.state
 
-    if (!this.validAddress()) {
+    if (!address || !this.validAddress()) {
       this.setState({ formInputError: accountManagement.sendBcpt.error.address })
       return
     } else if (!amount || amount === '0') {
@@ -72,9 +72,10 @@ class TransferBcpt extends Component<Props, State> {
       return
     }
 
+    const trimmedAddress = address.toLowerCase().startsWith('0x') ? address.substring(2) : address
     const success = await sendingBcptLoader.wrap(
       this.props.sendBcpt(
-        address as string,
+        trimmedAddress as string,
         amount as string
       )
     )
@@ -103,12 +104,12 @@ class TransferBcpt extends Component<Props, State> {
   }
 
   setAddress(address) {
-    return `${ethAddress(address)}`
+    return address
   }
 
   validAddress() {
     const { address } = this.state
-    return address && address.length === 40
+    return `${isEthAddress(address)}`
   }
 
   render() {
@@ -134,7 +135,7 @@ class TransferBcpt extends Component<Props, State> {
                     placeholder={accountManagement.sendBcpt.address}
                     placeholderTextColor='black'
                     value={address}
-                    maxLength={40}
+                    maxLength={42}
                     underlineColorAndroid='transparent'
                     onChangeText={address => this.setState({ address: this.setAddress(address) })}
                   />

--- a/packages/ui/dialogs/transfer-eth/index.tsx
+++ b/packages/ui/dialogs/transfer-eth/index.tsx
@@ -6,7 +6,7 @@ import firebase from 'react-native-firebase'
 import { getResetAction } from 'reducers/nav'
 
 import { UserData } from 'lndr/user'
-import { ethAmount, ethAddress, formatCommaDecimal, formatEthRemaining } from 'lndr/format'
+import { ethAmount, isEthAddress, formatCommaDecimal, formatEthRemaining } from 'lndr/format'
 import { currencySymbols, transferLimits, isCommaDecimal } from 'lndr/currencies'
 
 import Button from 'ui/components/button'
@@ -114,12 +114,12 @@ class TransferEth extends Component<Props, State> {
   }
 
   setAddress(address: string) {
-    return `${ethAddress(address)}`
+    return address
   }
 
   validAddress() {
     const { address } = this.state
-    return address && address.length === 40
+    return `${isEthAddress(address)}`
   }
 
   getLimit() {
@@ -206,5 +206,3 @@ class TransferEth extends Component<Props, State> {
 export default connect((state) => ({ user: getUser(state)(), ethBalance: getEthBalance(state), ethExchange: getEthExchange(state),
   ethSentPastWeek: getWeeklyEthTotal(state), primaryCurrency: getPrimaryCurrency(state), transferLimitLevel: getTransferLimitLevel(state) })
   , { sendEth })(TransferEth)
-
-  


### PR DESCRIPTION
This hot-fix for 1.4.1 (and beyond) includes the '0x' prefix when copying Lndr wallet addresses, and allows for '0x' when pasting a destination wallet address.

These changes should be also be incorporated into the subsequent ERC-20 code branch moving forward.