### PR TITLE
Show eth transaction cost

### DIFF
--- a/packages/actions/index.ts
+++ b/packages/actions/index.ts
@@ -25,7 +25,7 @@ import { jsonToPendingFriend, jsonToPendingTransaction, jsonToRecentTransaction,
 
 import { triggerTouchId, getEthInfo, generateMultiTransaction, filterMultiTransactions, resizeKYCImage } from './util'
 
-import CreditProtocol from 'credit-protocol'
+import CreditProtocol, { TransactionCosts } from 'credit-protocol'
 
 import language from 'language'
 const { accountManagement, debtManagement, settlementManagement, copiedClipboard, lndrVerified } = language
@@ -943,7 +943,7 @@ export const storeEthTransaction = async (dispatch, tx: object) => {
   }
 }
 
-export const getTransactionCosts = async (settlementType: string, currency: string) => {
+export const getTransactionCosts = async (settlementType: string, currency: string) : Promise<TransactionCosts> => {
   const gasNeeded = isEthSettlement(settlementType) ? GAS_TO_SETTLE_WITH_ETH : GAS_TO_SEND_ERC20
   return creditProtocol.getTransactionCosts(currency, gasNeeded)
 }

--- a/packages/actions/index.ts
+++ b/packages/actions/index.ts
@@ -943,9 +943,9 @@ export const storeEthTransaction = async (dispatch, tx: object) => {
   }
 }
 
-export const getTransactionCost = async (settlementType: string, currency: string) => {
+export const getTransactionCosts = async (settlementType: string, currency: string) => {
   const gasNeeded = isEthSettlement(settlementType) ? GAS_TO_SETTLE_WITH_ETH : GAS_TO_SEND_ERC20
-  return creditProtocol.getTxCost(currency, gasNeeded)
+  return creditProtocol.getTransactionCosts(currency, gasNeeded)
 }
 
 export const confirmFriendRequest = (friend: string) => {

--- a/packages/credit-protocol/index.ts
+++ b/packages/credit-protocol/index.ts
@@ -422,16 +422,26 @@ export default class CreditProtocol {
     try {
       const gasPrice = await this.getGasPrice()
       const rate = await this.getEthExchange(currency)
-      const ethCost = gasPrice * gasNeeded / WEI_PER_ETH
+      const weiCost = gasPrice * gasNeeded
+      const ethCost = weiCost / WEI_PER_ETH
       const currencyCost = Math.max( 0.01, ethCost * Number(rate) )
       return {
-        ethCost: `${ethCost}`.slice(0,6),
-        currencyCost: formatSettlementAmount(String(currencyCost), currency)
+        ethCost,
+        ethCostFormatted: `${ethCost}`.slice(0,6),
+        currencyCost,
+        currencyFormatted: formatSettlementAmount(String(currencyCost), currency),
+        weiCost
       }
     } catch (e) {
     }
 
-    return { ethCost: '0', currencyCost: formatSettlementAmount('0.00', currency) }
+    return {
+      ethCost: 0,
+      ethCostFormatted: '0',
+      currencyCost: 0,
+      currencyCostFormatted: formatSettlementAmount('0.00', currency),
+      weiCost: 0
+    }
   }
 
   async getEthExchange(currency: string) {

--- a/packages/credit-protocol/index.ts
+++ b/packages/credit-protocol/index.ts
@@ -418,15 +418,19 @@ export default class CreditProtocol {
     return config.gasPrice
   }
 
-  async getTxCost(currency: string, gasNeeded: number) {
+  async getTransactionCosts(currency: string, gasNeeded: number) {
     try {
       const gasPrice = await this.getGasPrice()
       const rate = await this.getEthExchange(currency)
+      const ethCost = gasPrice * gasNeeded / WEI_PER_ETH
 
-      return `${Math.max( 0.01, gasPrice * Number(rate) * gasNeeded / WEI_PER_ETH )}`.slice(0,6)
+      return {
+        ethCost: `${ethCost}`.slice(0,6),
+        currencyCost: `${Math.max( 0.01, ethCost * Number(rate) )}`.slice(0,6)
+      }
     } catch (e) {}
 
-    return '0.00'
+    return { ethCost: '0', currencyCost: '0.00' }
   }
 
   async getEthExchange(currency: string) {

--- a/packages/credit-protocol/index.ts
+++ b/packages/credit-protocol/index.ts
@@ -21,6 +21,22 @@ import { ERC20_Transaction, WEI_PER_ETH, getERC20_token } from 'lndr/erc-20'
 import Tx from 'ethereumjs-tx'
 import web3 from 'lndr/web3-connection'
 
+export interface TransactionCosts {
+  ethCost: number,
+  ethCostFormatted: string,
+  currencyCost: number,
+  currencyCostFormatted: string,
+  weiCost: number
+}
+
+export const defaultTransactionCosts = () : TransactionCosts => ({
+  ethCost: 0,
+  ethCostFormatted: '',
+  currencyCost: 0,
+  currencyCostFormatted: '',
+  weiCost: 0
+})
+
 export default class CreditProtocol {
   client: Client
   tempStorage: any
@@ -418,7 +434,7 @@ export default class CreditProtocol {
     return config.gasPrice
   }
 
-  async getTransactionCosts(currency: string, gasNeeded: number) {
+  async getTransactionCosts(currency: string, gasNeeded: number) : Promise<TransactionCosts> {
     try {
       const gasPrice = await this.getGasPrice()
       const rate = await this.getEthExchange(currency)
@@ -428,7 +444,7 @@ export default class CreditProtocol {
 
       return {
         ethCost,
-        ethCostFormatted: `${ethCost}`.slice(0,6),
+        ethCostFormatted: `${ethCost}`.slice(0,7),
         currencyCost,
         currencyCostFormatted: `${currencySymbols(currency)}${formatSettlementCurrencyAmount(String(currencyCost), false)}`,
         weiCost
@@ -436,13 +452,7 @@ export default class CreditProtocol {
     } catch (e) {
     }
 
-    return {
-      ethCost: 0,
-      ethCostFormatted: '0',
-      currencyCost: 0,
-      currencyCostFormatted: formatSettlementAmount('0.00', currency),
-      weiCost: 0
-    }
+    return defaultTransactionCosts()
   }
 
   async getEthExchange(currency: string) {

--- a/packages/credit-protocol/index.ts
+++ b/packages/credit-protocol/index.ts
@@ -450,6 +450,7 @@ export default class CreditProtocol {
         weiCost
       }
     } catch (e) {
+      console.log('ERROR TRANSACTION COSTS', e)
     }
 
     return defaultTransactionCosts()

--- a/packages/credit-protocol/index.ts
+++ b/packages/credit-protocol/index.ts
@@ -13,8 +13,8 @@ import Client from './lib/client'
 import CreditRecord from './lib/credit-record'
 export { default as CreditRecord } from './lib/credit-record'
 
-import { hasNoDecimals } from 'lndr/currencies'
-import { formatSettlementAmount, isERC20Settlement } from 'lndr/format'
+import { currencySymbols, hasNoDecimals } from 'lndr/currencies'
+import { formatSettlementCurrencyAmount, formatSettlementAmount, isERC20Settlement } from 'lndr/format'
 import KYC from 'lndr/kyc'
 
 import { ERC20_Transaction, WEI_PER_ETH, getERC20_token } from 'lndr/erc-20'
@@ -425,11 +425,12 @@ export default class CreditProtocol {
       const weiCost = gasPrice * gasNeeded
       const ethCost = weiCost / WEI_PER_ETH
       const currencyCost = Math.max( 0.01, ethCost * Number(rate) )
+
       return {
         ethCost,
         ethCostFormatted: `${ethCost}`.slice(0,6),
         currencyCost,
-        currencyFormatted: formatSettlementAmount(String(currencyCost), currency),
+        currencyCostFormatted: `${currencySymbols(currency)}${formatSettlementCurrencyAmount(String(currencyCost), false)}`,
         weiCost
       }
     } catch (e) {

--- a/packages/credit-protocol/index.ts
+++ b/packages/credit-protocol/index.ts
@@ -14,7 +14,7 @@ import CreditRecord from './lib/credit-record'
 export { default as CreditRecord } from './lib/credit-record'
 
 import { hasNoDecimals } from 'lndr/currencies'
-import { isERC20Settlement } from 'lndr/format'
+import { formatSettlementAmount, isERC20Settlement } from 'lndr/format'
 import KYC from 'lndr/kyc'
 
 import { ERC20_Transaction, WEI_PER_ETH, getERC20_token } from 'lndr/erc-20'
@@ -423,14 +423,15 @@ export default class CreditProtocol {
       const gasPrice = await this.getGasPrice()
       const rate = await this.getEthExchange(currency)
       const ethCost = gasPrice * gasNeeded / WEI_PER_ETH
-
+      const currencyCost = Math.max( 0.01, ethCost * Number(rate) )
       return {
         ethCost: `${ethCost}`.slice(0,6),
-        currencyCost: `${Math.max( 0.01, ethCost * Number(rate) )}`.slice(0,6)
+        currencyCost: formatSettlementAmount(String(currencyCost), currency)
       }
-    } catch (e) {}
+    } catch (e) {
+    }
 
-    return { ethCost: '0', currencyCost: '0.00' }
+    return { ethCost: '0', currencyCost: formatSettlementAmount('0.00', currency) }
   }
 
   async getEthExchange(currency: string) {

--- a/packages/language/languages/ar.ts
+++ b/packages/language/languages/ar.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `تحويل كل شيء`,
       balance: Y => `رصيدك الحالي من الإثيريوم هو ${typeof Y === 'string' ? Y.slice(0,8) :''}`,
       ethAddress: `عنوان إثيريوم`,
-      txCost: (B, A) => `تكلفة المعاملة الحالية هو ${CUR(A)}${B}`,
       transferLowercase: `تحويل إثيريوم`,
       note: (A, M) => `يرجى الانتباه: يمكنك فقط تحويل ${CUR(A)} ${TL(A, M)} في الأسبوع من Lndr`,
       warning: (Z, A, M) => `لديك ${CUR(A)}${Z} متبقي من حدك ${CUR(A)} ${TL(A, M)}`,
@@ -213,6 +212,7 @@ export default {
       address: `عنوان الوجهة`,
       balance: (name, balance) => `رصيدك الحالي من ${name} هو ${typeof balance === 'string' ? balance.slice(0,8) :''}`,
       tokenAddress: (name) => `عنوان ${name}`,
+      txCost: (ethCost, currencyCost) => `(${currencyCost}) ETH ${ethCost} :تكلفة المعاملة`,
     },
     panelHeaders: [
       `محفظة عنوان`,

--- a/packages/language/languages/cs.ts
+++ b/packages/language/languages/cs.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Převést vše`,
       balance: Y => `Aktuální zůstatek ETH je ${typeof Y === 'string' ? Y.slice(0,8) :''}`,
       ethAddress: `Ethereum adresa`,
-      txCost: (B, A) => `Aktuální cena transakce je ${CUR(A)}${B}`,
       transferLowercase: `Převést Eth`,
       note: (A, M) => `Poznámka: můžete převést max. ${CUR(A)} ${TL(A, M)} týdně z Lndr`,
       warning: (Z, A, M) => `Zbývá vám ${CUR(A)}${Z} z vašeho limitu ${CUR(A)} ${TL(A, M)}`,
@@ -213,6 +212,7 @@ export default {
       address: `Cílová adresa`,
       balance: (name, balance) => `Aktuální ${name} zůstatek je ${typeof balance === 'string' ? balance.slice(0,8) :''}`,
       tokenAddress: (name) => `${name} adresa`,
+      txCost: (ethCost, currencyCost) => `Transakční náklady: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Peněženka Address`,

--- a/packages/language/languages/da.ts
+++ b/packages/language/languages/da.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Overfør alt`,
       balance: Y => `Din aktuelle ETH saldo er ${typeof Y === 'string'? Y.slice (0,8): ''} `,
       ethAddress: `Ethereum Adresse`,
-      txCost: (B, A) => `Den nuværende transaktionspris er ${CUR(A)}${B}`,
       transferLowercase: `Overfør Eth`,
       note: (A, M) => `Bemærk: du kan kun overføre ${CUR(A)} ${TL(A, M)} om ugen på Lndr`,
       warning: (Z, A, M) => `Du har ${CUR(A)}${Z} resterende af din ${CUR(A)} ${TL(A, M)} grænse`,
@@ -213,6 +212,7 @@ export default {
       address: `Destinationsadresse`,
       balance: (name, balance) => `Din aktuelle ${name} saldo er ${typeof balance === 'string'? balance.slice(0,8):''} `,
       tokenAddress: (name) => `${name} Adresse`,
+      txCost: (ethCost, currencyCost) => `Transaktionsomkostninger: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Wallet Adresse`,

--- a/packages/language/languages/de.ts
+++ b/packages/language/languages/de.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Überweisen Sie alles`,
       balance: Y => `Ihr aktueller ETH-Kontostand ist ${typeof Y === 'string'? Y.slice (0,8): ''} `,
       ethAddress: `Ethereum-Adresse`,
-      txCost: (B, A) => `Die aktuelle Transaktion kostet ${CUR(A)} ${B}`,
       transferLowercase: `Eth-Überweisung`,
       note: (A, M) => `Bitte beachten Sie: Sie können nur ${CUR(A)} ${TL(A, M)} pro Woche aus Lndr überweisen`,
       warning: (Z, A, M) => `Sie haben ${CUR(A)} ${Z} übrig von Ihrem ${CUR(A)} ${TL(A, M)} Limit`,
@@ -213,6 +212,7 @@ export default {
       address: `Zieladresse`,
       balance: (name, balance) => `Ihr aktueller ${name}-Kontostand ist ${typeof balance === 'string'? balance.slice (0,8): ''} `,
       tokenAddress: (name) => `${name}-Adresse`,
+      txCost: (ethCost, currencyCost) => `Transaktionskosten: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Wallet-Adresse`,

--- a/packages/language/languages/el.ts
+++ b/packages/language/languages/el.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Μεταφορά όλων`,
       balance: Y => `Το τρέχον υπόλοιπο ETH σας είναι ${typeof Y ==='string' ? Y.slice (0,8): ''} `,
       ethAddress: `Διεύθυνση Ethereum`,
-      txCost: (Β, A) => `Το τρέχον κόστος συναλλαγής είναι ${CUR(A)}${Β}`,
       transferLowercase: `Μεταφορά Eth`,
       note: (A, M) => `Παρακαλώ σημειώστε: μπορείτε να μεταφέρετε μόνο ${CUR(A)} ${TL(A, M)} την εβδομάδα εκτός Lndr`,
       warning: (Z, A, M) => `Έχετε ${CUR(A)} ${Z} υπόλοιπο ${CUR(A)} ${TL(A, M)} στο όριό σας`,
@@ -213,6 +212,7 @@ export default {
       address: `Διεύθυνση Προορισμού`,
       balance: (name, balance) => `Το τρέχον υπόλοιπο ${name} σας είναι ${typeof balance === 'string' ? balance.slice (0,8): ''} `,
       tokenAddress: (name) => `Διεύθυνση ${name}`,
+      txCost: (ethCost, currencyCost) => `Κόστος συναλλαγής: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Πορτοφόλι Διεύθυνση`,

--- a/packages/language/languages/en.ts
+++ b/packages/language/languages/en.ts
@@ -197,7 +197,7 @@ export default {
       transferAll: `TRANSFER EVERYTHING`,
       balance: (balance) => `Your current ETH balance is ${typeof balance === 'string' ? balance.slice(0,8) :''}`,
       ethAddress: `Ethereum Address`,
-      txCost: (ethCost, currencyCost, currency) => `Transaction cost is ${ethCost} ETH (${currencySymbols(currency)}${currencyCost})`,
+      txCost: (ethCost, currencyCost) => `Transaction cost is ${ethCost} ETH (${currencyCost})`,
       transferLowercase: `Transfer Eth`,
       note: (currency, multiplier) => `Please note: you can only transfer ${currencySymbols(currency)}${TL(currency, multiplier)} per week out of Lndr`,
       warning: (amount, currency, multiplier) => `You have ${currencySymbols(currency)}${amount} remaining of your ${currencySymbols(currency)}${TL(currency, multiplier)} limit`,

--- a/packages/language/languages/en.ts
+++ b/packages/language/languages/en.ts
@@ -197,7 +197,6 @@ export default {
       transferAll: `TRANSFER EVERYTHING`,
       balance: (balance) => `Your current ETH balance is ${typeof balance === 'string' ? balance.slice(0,8) :''}`,
       ethAddress: `Ethereum Address`,
-      txCost: (ethCost, currencyCost) => `Transaction cost is ${ethCost} ETH (${currencyCost})`,
       transferLowercase: `Transfer Eth`,
       note: (currency, multiplier) => `Please note: you can only transfer ${currencySymbols(currency)}${TL(currency, multiplier)} per week out of Lndr`,
       warning: (amount, currency, multiplier) => `You have ${currencySymbols(currency)}${amount} remaining of your ${currencySymbols(currency)}${TL(currency, multiplier)} limit`,
@@ -211,6 +210,7 @@ export default {
       address: `Destination Address`,
       balance: (name, balance) => `Your current ${name} balance is ${typeof balance === 'string' ? balance.slice(0,8) :''}`,
       tokenAddress: (name) => `${name} Address`,
+      txCost: (ethCost, currencyCost) => `Transaction cost: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Wallet Address`,

--- a/packages/language/languages/en.ts
+++ b/packages/language/languages/en.ts
@@ -197,7 +197,7 @@ export default {
       transferAll: `TRANSFER EVERYTHING`,
       balance: (balance) => `Your current ETH balance is ${typeof balance === 'string' ? balance.slice(0,8) :''}`,
       ethAddress: `Ethereum Address`,
-      txCost: (cost, currency) => `The current transaction cost is ${currencySymbols(currency)}${cost}`,
+      txCost: (ethCost, currencyCost, currency) => `Transaction cost is ${ethCost} ETH (${currencySymbols(currency)}${currencyCost})`,
       transferLowercase: `Transfer Eth`,
       note: (currency, multiplier) => `Please note: you can only transfer ${currencySymbols(currency)}${TL(currency, multiplier)} per week out of Lndr`,
       warning: (amount, currency, multiplier) => `You have ${currencySymbols(currency)}${amount} remaining of your ${currencySymbols(currency)}${TL(currency, multiplier)} limit`,

--- a/packages/language/languages/es.ts
+++ b/packages/language/languages/es.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Transferir Todo`,
       balance: Y => `Su saldo actual en ETH (Ethereum) es de ${typeof Y === 'string' ? Y.slice (0,8): ''} `,
       ethAddress: `Dirección Ethereum`,
-      txCost: (B, A) => `El costo de la transacción actual es de: ${CUR(A)} ${B}`,
       transferLowercase: `Transferir ETH (Ethereum)`,
       note: (A, M) => `Atención: sólo se puede transferir ${CUR(A)} ${TL(A, M)} por semana a través de Lndr`,
       warning: (Z, A, M) => `Le quedan ${CUR(A)} ${Z} restantes de su ${CUR(A)} ${TL(A, M)} límite`,
@@ -213,6 +212,7 @@ export default {
       address: `Dirección de Destino`,
       balance: (name, balance) => `Su saldo actual de ${name} es:  ${typeof balance === 'string'? balance.slice (0,8): ''}`,
       tokenAddress: (name) => `Dirección ${name}`,
+      txCost: (ethCost, currencyCost) => `Costo de transacción: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Monedero Dirección`,

--- a/packages/language/languages/fi.ts
+++ b/packages/language/languages/fi.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Siirrä kaikki`,
       balance: Y => `Nykyinen ETH-saldosi on ${typeof Y === 'string' ? Y.slice (0,8): ''} `,
       ethAddress: `Ethereum-osoite`,
-      txCost: (B, A) => `Nykyinen tapahtuma maksaa ${CUR(A)} ${B}`,
       transferLowercase: `Siirrä Eth`,
       note: (A, M) => `Huom.: Voit siirtää Lndr-sovelluksesta vain ${CUR(A)} ${TL(A, M)} viikossa`,
       warning: (Z, A, M) => `Sinulla on jäljellä ${CUR(A)} ${Z}, ennen kuin saavutat ${CUR(A)} ${TL(A, M)} ylärajasi`,
@@ -213,6 +212,7 @@ export default {
       address: `Kohdeosoite`,
       balance: (name, balance) => `Nykyinen ${name}-saldosi on ${typeof balance === 'string' ? balance.slice (0,8): ''} `,
       tokenAddress: (name) => `${name}-Osoite`,
+      txCost: (ethCost, currencyCost) => `Tapahtumakustannukset: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Lompakko Osoite`,

--- a/packages/language/languages/fr.ts
+++ b/packages/language/languages/fr.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Tout transférer`,
       balance: Y => `Votre solde en ETH est de ${typeof Y === 'string'? Y.slice (0,8): ''} `,
       ethAddress: `Adresse Ethereum`,
-      txCost: (B, A) => `Le coût actuel de la transaction est de ${CUR(A)} ${B}`,
       transferLowercase: `Transférer de l'ETH`,
       note: (A, M) => `Merci de noter que vous ne pouvez transférer que ${CUR(A)} ${TL(A, M)} par semaine sur Lndr`,
       warning: (Z, A, M) => `Vous avez ${CUR(A)} ${Z} restants sur votre limite de ${CUR(A)} ${TL(A, M)} `,
@@ -213,6 +212,7 @@ export default {
       address: `Adresse de destination`,
       balance: (name, balance) => `Votre solde en ${name} est de ${typeof balance === 'string'? balance.slice (0,8): ''} `,
       tokenAddress: (name) => `Adresse ${name}`,
+      txCost: (ethCost, currencyCost) => `Coût de la transaction: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Adresse Wallet`,

--- a/packages/language/languages/hi.ts
+++ b/packages/language/languages/hi.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `सब-कुछ ट्रान्सफर करें`,
       balance: Y => `आपका वर्तमान ETH बैलेन्स है ${typeof Y === 'string' ? Y.slice(0,8) :''}`,
       ethAddress: `Ethereum पता`,
-      txCost: (B, A) => `वर्तमान ट्रैंज़ैक्शन खर्च है ${CUR(A)}${B}`,
       transferLowercase: `Eth ट्रान्सफर`,
       note: (A, M) => `कृपया नोट करें: आप हर हफ्ते केवल ${CUR(A)} ${TL(A, M)} ही Lndr से बाहर भेज सकते हैं`,
       warning: (Z, A, M) => `आपकी ${CUR(A)} ${TL(A, M)} लिमिट में ${CUR(A)}${Z} बाकी है`,
@@ -213,6 +212,7 @@ export default {
       address: `गंतव्य पता`,
       balance: (name, balance) => `आपका वर्तमान ${name} बैलेन्स ${typeof balance === 'string' ? balance.slice(0,8) :''} हैं`,
       tokenAddress: (name) => `${name} पता`,
+      txCost: (ethCost, currencyCost) => `लेनदेन लागत: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `बटुआ पता`,

--- a/packages/language/languages/hu.ts
+++ b/packages/language/languages/hu.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Minden átutalása`,
       balance: Y => `Jelenlegi ETH egyenlege ${typeof Y === 'string'? Y.slice (0,8): ''} `,
       ethAddress: `Ethereum Cím`,
-      txCost: (B, A) => `Jelenlegi tranzakciós költsége ${CUR(A)} ${B}`,
       transferLowercase: `Eth Átutalása`,
       note: (A, M) => `Kérjük, vegye figyelembe: a Lndr rendszerén kívül hetente csak ${CUR(A)} ${TL(A, M)} összeget utalhat át`,
       warning: (Z, A, M) => `${CUR(A)} ${Z} a fennmaradó összeg a ${CUR(A)} ${TL(A, M)} limitjéből:`,
@@ -213,6 +212,7 @@ export default {
       address: `Rendeltetési Cím`,
       balance: (name, balance) => `Jelenlegi ${name} egyenlege ${typeof balance === 'string'? balance.slice (0,8): ''} `,
       tokenAddress: (name) => `${name} Cím`,
+      txCost: (ethCost, currencyCost) => `Tranzakciós költség: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Wallet Cím`,

--- a/packages/language/languages/in.ts
+++ b/packages/language/languages/in.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Transfer Semuanya`,
       balance: Y => `Saldo ETH Anda saat ini adalah ${typeof Y === 'string' ? Y.slice(0,8) :''}.`,
       ethAddress: `Alamat Ethereum`,
-      txCost: (B, A) => `Biaya transaksi saat ini adalah ${CUR(A)}${B}.`,
       transferLowercase: `Transfer ETH`,
       note: (A, M) => `Perhatian: Anda hanya dapat mentransfer ${CUR(A)} ${TL(A, M)} per minggu dari Lndr.`,
       warning: (Z, A, M) => `Anda memiliki ${CUR(A)}${Z} tersisa dari batas ${CUR(A)} ${TL(A, M)} Anda.`,
@@ -213,6 +212,7 @@ export default {
       address: `Alamat Tujuan`,
       balance: (name, balance) => `Saldo ${name} Anda saat ini adalah ${typeof balance === 'string' ? balance.slice(0,8) :''}.`,
       tokenAddress: (name) => `Alamat ${name}`,
+      txCost: (ethCost, currencyCost) => `Biaya transaksi: ${ethCost} ETH (${currencyCost}).`,
     },
     panelHeaders: [
       `Dompet Alamat`,

--- a/packages/language/languages/it.ts
+++ b/packages/language/languages/it.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Trasferire tutto`,
       balance: Y => `Il tuo saldo corrente è ETH ${typeof Y === 'string'? Y.slice (0,8): ''} `,
       ethAddress: `Indirizzo Ethereum`,
-      txCost: (B, A) => `Il costo della transazione corrente è di ${CUR(A)} ${B}`,
       transferLowercase: `Trasferimento Eth`,
       note: (A, M) => `Si prega di notare: è possibile trasferire solo ${CUR(A)} ${TL(A, M)} a settimana fuori Lndr`,
       warning: (Z, A, M) => `Ti sono rimasti ${CUR(A)}${Z} del tuo limite ${CUR(A)} ${TL(A, M)}`,
@@ -213,6 +212,7 @@ export default {
       address: `Indirizzo di destinazione`,
       balance: (name, balance) => `Il tuo attuale saldo ${name} è ${typeof balance === 'string' ? balance.slice(0,8) :''}`,
       tokenAddress: (name) => `Indirizzo ${name}`,
+      txCost: (ethCost, currencyCost) => `Costo transazione: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Portafoglio Indirizzo`,

--- a/packages/language/languages/iw.ts
+++ b/packages/language/languages/iw.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `להעביר הכל`,
       balance: Y => `${typeof Y === 'string' ? Y.slice(0,8) :''} הנוכחית שלך היא ETH- יתרת ה`,
       ethAddress: `כתובת Ethereum`,
-      txCost: (B, A) => `${CUR(A)}${B} מחיר ההעברה הנוכחי הוא`,
       transferLowercase: `להעביר Eth`,
       note: (A, M) => `Lndr-בלבד מחוץ ל ${CUR(A)} ${TL(A, M)} שים לב: אתה יכול להעביר בשבוע`,
       warning: (Z, A, M) => `שלך ${CUR(A)} ${TL(A, M)} -מהמגבלת ה ${CUR(A)}${Z} נותרו לך`,
@@ -213,6 +212,7 @@ export default {
       address: `כתובת יעד`,
       balance: (name, balance) => ` ${typeof balance === 'string' ? balance.slice(0,8) :''} שלך היא ${name} -יתרת ה`,
       tokenAddress: (name) => `כתובת ${name}`,
+      txCost: (ethCost, currencyCost) => `(${currencyCost}) ETH ${ethCost} :עלות העסקה`,
     },
     panelHeaders: [
       `כתובת ארנק`,

--- a/packages/language/languages/ja.ts
+++ b/packages/language/languages/ja.ts
@@ -198,7 +198,6 @@ export default {
       transferAll: `全てを送金する`,
       balance: Y => `あなたの現在のETH残高は${typeof Y === 'string' ? Y.slice(0,8) :''}です`,
       ethAddress: `イーサリアムアドレス`,
-      txCost: (B, A) => `現在の取引手数料は ${CUR(A)}${B}です`,
       transferLowercase: `ETHを送金する`,
       note: (A, M) => `一週間にLndrから引き出せるのは ${CUR(A)} ${TL(A, M)} までです`,
       warning: (Z, A, M) => `現在 ${CUR(A)} ${TL(A, M)} のうち ${CUR(A)}${Z}残っています `,
@@ -212,6 +211,7 @@ export default {
       address: `送付先アドレス`,
       balance: (name, balance) => `あなたの現在の${name}残高は${typeof balance === 'string' ? balance.slice(0,8) :''}`,
       tokenAddress: (name) => `${name}アドレス`,
+      txCost: (ethCost, currencyCost) => `取引コスト： ${ethCost} ETH (${currencyCost}) です`,
     },
     panelHeaders: [
       `ウォレット住所`,

--- a/packages/language/languages/ko.ts
+++ b/packages/language/languages/ko.ts
@@ -200,7 +200,6 @@ export default {
       transferAll: `전액 송금`,
       balance: (balance) => `당신의 현재 이더리움 잔액은 ${typeof balance === 'string' ? balance.slice(0,8) : ''}`,
       ethAddress: `이더리움 주소`,
-      txCost: (cost, A) => `현재 이더리움 거래에 드는 비용은 한 거래당 ${CUR(A)}${cost} 달러입니다`,
       transferLowercase: `이더리움 송금`,
       note: (A, M) => `참고 : Lndr에서는 일주일에 ${CUR(A)} ${TL(A, M)} 만 송금할 수 있습니다.`,
       warning: (Z, A, M) => `귀하의 거래 한도 ${CUR(A)}${Z} 중 ${CUR(A)} ${TL(A, M)} 이 남아있습니다`
@@ -214,6 +213,7 @@ export default {
       address: `수신지 주소`,
       balance: (name, balance) => `당신의 현재 ${name} 잔액은 ${typeof balance === 'string' ? balance.slice(0,8) : ''}`,
       tokenAddress: (name) => `${name} 주소`,
+      txCost: (ethCost, currencyCost) => `거래 비용 : ${ethCost} ETH (${currencyCost}) 달러입니다`,
     },
     panelHeaders: [
       `지갑 주소`,

--- a/packages/language/languages/ms.ts
+++ b/packages/language/languages/ms.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Pindahkan semua`,
       balance: Y => `Baki semasa ETH anda ialah ${typeof Y === 'string' ? Y.slice (0,8): ''} `,
       ethAddress: `Alamat Ethereum`,
-      txCost: (B, A) => `Kos transaksi semasa adalah ${CUR(A)}${B}`,
       transferLowercase: `Pindahkan ETH`,
       note: (A, M) => `Sila ambil perhatian: anda hanya boleh memindahkan ${CUR(A)} ${TL(A, M)} setiap minggu daripada Lndr`,
       warning: (Z, A, M) => `Anda mempunyai ${CUR(A)}${Z} baki daripada ${CUR(A)} ${TL(A, M)} had anda`,
@@ -213,6 +212,7 @@ export default {
       address: `Alamat Destinasi`,
       balance: (name, balance) => `Baki semasa ${name} anda ialah ${typeof balance === 'string' ? balance.slice(0,8) : ''} `,
       tokenAddress: (name) => `Alamat ${name}`,
+      txCost: (ethCost, currencyCost) => `Kos urus niaga: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Alamat Wallet`,

--- a/packages/language/languages/nb.ts
+++ b/packages/language/languages/nb.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Overfør alt`,
       balance: Y => `Din nåværende ETH saldo er ${typeof Y === 'string' ? Y.slice (0,8) :''} `,
       ethAddress: `Ethereum adresse`,
-      txCost: (B, A) => `De aktuelle transaksjonskostnader er ${CUR(A)}${B}`,
       transferLowercase: `Overfør Eth`,
       note: (A, M) => `Merk: Du kan bare overføre ${CUR(A)} ${TL(A, M)} per uke ut av Lndr`,
       warning: (Z, A, M) => `Du har ${CUR(A)}${Z} igjen av ditt ${CUR(A)} ${TL(A, M)} maksbeløpet`,
@@ -213,6 +212,7 @@ export default {
       address: `Bestemmelsesadresse`,
       balance: (name, balance) => `Din nåværende ${name} saldo er ${typeof balance === 'string' ? balance.slice(0,8) :''} `,
       tokenAddress: (name) => `${name} Adresse`,
+      txCost: (ethCost, currencyCost) => `Transaksjonskostnad: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Lommebok Adresse`,

--- a/packages/language/languages/nl.ts
+++ b/packages/language/languages/nl.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Boek alles over`,
       balance: Y => `Uw huidige ETH saldo is ${typeof Y === 'string'? Y.slice(0,8) : ''} `,
       ethAddress: `Ethereum Adres`,
-      txCost: (B, A) => `De huidige transactie kost ${CUR(A)}${B}`,
       transferLowercase: `Boek ETH over`,
       note: (A, M) => `Let op: u kunt maar ${CUR(A)} ${TL(A, M)} per week overboeken uit Lndr`,
       warning: (Z, A, M) => `U heeft ${CUR(A)}${Z} over van uw ${CUR(A)} ${TL(A, M)} limiet`,
@@ -213,6 +212,7 @@ export default {
       address: `Ontvangstadres`,
       balance: (name, balance) => `Uw huidige ${name} saldo is ${typeof balance === 'string'? balance.slice (0,8) : ''} `,
       tokenAddress: (name) => `${name} Adres`,
+      txCost: (ethCost, currencyCost) => `Transactiekosten: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Wallet Adres`,

--- a/packages/language/languages/no.ts
+++ b/packages/language/languages/no.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Overfør alt`,
       balance: Y => `Din nåværende ETH saldo er ${typeof Y === 'string' ? Y.slice (0,8) :''} `,
       ethAddress: `Ethereum adresse`,
-      txCost: (B, A) => `De aktuelle transaksjonskostnader er ${CUR(A)}${B}`,
       transferLowercase: `Overfør Eth`,
       note: (A, M) => `Merk: Du kan bare overføre ${CUR(A)} ${TL(A, M)} per uke ut av Lndr`,
       warning: (Z, A, M) => `Du har ${CUR(A)}${Z} igjen av ditt ${CUR(A)} ${TL(A, M)} maksbeløpet`,
@@ -213,6 +212,7 @@ export default {
       address: `Bestemmelsesadresse`,
       balance: (name, balance) => `Din nåværende ${name} saldo er ${typeof balance === 'string' ? balance.slice(0,8) :''} `,
       tokenAddress: (name) => `${name} Adresse`,
+      txCost: (ethCost, currencyCost) => `Transaksjonskostnad: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Lommebok Adresse`,

--- a/packages/language/languages/pl.ts
+++ b/packages/language/languages/pl.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Prześlij wszystko`,
       balance: Y => `Obecne saldo ETH wynosi ${typeof Y === 'string'? Y.slice (0,8): ''} `,
       ethAddress: `Adres Ethereum`,
-      txCost: (B, A) => `Obecny koszt transakcji to ${CUR(A)} ${B}`,
       transferLowercase: `Przelew ETH`,
       note: (A, M) => `Uwaga: można wysłać tylko ${CUR(A)} ${TL(A, M)} tygodniowo z Lndr`,
       warning: (Z, A, M) => `masz ${CUR(A)} ${Z} z Twojego limitu równego ${CUR(A)} ${TL(A, M)}`,
@@ -213,6 +212,7 @@ export default {
       address: `Adres docelowy`,
       balance: (name, balance) => `Obecne saldo ${name} wynosi ${typeof balance === 'string' ? balance.slice (0,8): ''} `,
       tokenAddress: (name) => `Adres ${name}`,
+      txCost: (ethCost, currencyCost) => `Koszt transakcji: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Portfel Adres`,

--- a/packages/language/languages/pt.ts
+++ b/packages/language/languages/pt.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Transferir tudo`,
       balance: Y => `Seu saldo ETH atual é de R ${typeof Y === 'string'? Y.slice (0,8): ''} `,
       ethAddress: `Endereço Ethereum`,
-      txCost: (B, A) => `O custo de transação atual é de R ${CUR(A)} ${B}`,
       transferLowercase: `Transferir Eth`,
       note: (A, M) => `Por favor, note: você só pode transferir ${CUR(A)} ${TL(A, M)} por semana no Lndr`,
       warning: (Z, A, M) => `Você tem ${CUR(A)} ${Z} remanescente do seu ${CUR(A)} ${TL(A, M)} limite`,
@@ -213,6 +212,7 @@ export default {
       address: `Endereço de destino`,
       balance: (name, balance) => `Seu saldo ${name} atual é de R ${typeof balance === 'string' ? balance.slice (0,8): ''} `,
       tokenAddress: (name) => `Endereço ${name}`,
+      txCost: (ethCost, currencyCost) => `Custo de transação: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Carteira Endereço`,

--- a/packages/language/languages/ru.ts
+++ b/packages/language/languages/ru.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Перевести все`,
       balance: Y => `Ваш текущий баланс ETH ${typeof Y === 'string'? Y.slice (0,8): ''} `,
       ethAddress: `Ethereum Адрес`,
-      txCost: (B, А) => `Текущая стоимость транзакции составляет ${CUR(А)} ${B}`,
       transferLowercase: `Перевидение ETH`,
       note: (A, M) => `Пожалуйста, обратите внимание: вы можете передать ${CUR(A)} ${TL(A, M)} в неделю из Lndr`,
       warning: (Z, A, M) => `У вас есть ${CUR(A)} ${Z} в ваши ${CUR(A)} ${TL(A, M)} limit`,
@@ -213,6 +212,7 @@ export default {
       address: `Адрес назначения`,
       balance: (name, balance) => `Ваш текущий баланс ${name} ${typeof balance === 'string' ? balance.slice (0,8): ''} `,
       tokenAddress: (name) => `${name} Адрес`,
+      txCost: (ethCost, currencyCost) => `Стоимость транзакции: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Кошелек Адрес`,

--- a/packages/language/languages/sv.ts
+++ b/packages/language/languages/sv.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Överför allt`,
       balance: Y => `Ditt aktuella ETH saldo är ${typeof Y === 'string' ? Y.slice (0,8): ''} `,
       ethAddress: `Ethereum Adress`,
-      txCost: (B, A) => `Den aktuella transaktionskostnaden är ${CUR(A)} ${B}`,
       transferLowercase: `Överför Eth`,
       note: (A, M) => `Observera: Du kan endast överföra ${CUR(A)} ${TL(A, M)} per vecka från Lndr`,
       warning: (Z, A, M) => `Du har ${CUR(A)} ${Z} återstående av din ${CUR(A)} ${TL(A, M)} gräns`,
@@ -213,6 +212,7 @@ export default {
       address: `Mottagaradress`,
       balance: (name, balance) => `Ditt aktuella ${name} saldo är ${typeof balance === 'string'? balance.slice (0,8): ''} `,
       tokenAddress: (name) => `${name} Adress`,
+      txCost: (ethCost, currencyCost) => `Transaktionskostnad: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Plånbok Adress`,

--- a/packages/language/languages/th.ts
+++ b/packages/language/languages/th.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `โอนทุกอย่าง`,
       balance: Y => `ยอด ETH คงเหลือในปัจจุบันของคุณคือ ${typeof Y === 'string' ? Y.slice(0,8) :''}`,
       ethAddress: `ที่อยู่ Ethereum`,
-      txCost: (B, A) => `ค่าใช้จ่ายในการทำธุรกรรมในปัจจุบันคือ ${CUR(A)}${B}`,
       transferLowercase: `โอน Eth`,
       note: (A, M) => `โปรดทราบ: คุณสามารถโอนจาก Lndr ได้ ${CUR(A)} ${TL(A, M)} ต่อสัปดาห์เท่านั้น`,
       warning: (Z, A, M) => `คุณเหลือ ${CUR(A)}${Z} จากขีดจำกัด ${CUR(A)} ${TL(A, M)} ของคุณ`,
@@ -213,6 +212,7 @@ export default {
       address: `ที่อยู่ปลายทาง`,
       balance: (name, balance) => `ยอด ${name} คงเหลือในปัจจุบันของคุณคือ ${typeof balance === 'string' ? balance.slice(0,8) :''}`,
       tokenAddress: (name) => `ที่อยู่ ${name}`,
+      txCost: (ethCost, currencyCost) => `ค่าใช้จ่ายในการทำธุรกรรม: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `ที่อยู่ Wallet`,

--- a/packages/language/languages/tr.ts
+++ b/packages/language/languages/tr.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Her şeyi aktarın`,
       balance: Y => `Mevcut ETH bakiyeniz ${typeof Y === 'string' ? Y.slice(0,8) :''}`,
       ethAddress: `Ethereum Adresi`,
-      txCost: (B, A) => `Mevcut işlem maliyeti ${CUR(A)}${B} 'dir` ,
       transferLowercase: `ETH Aktar`,
       note: (A, M) => `Lütfen dikkat: Lndr dışına haftada sadece ${CUR(A)} ${TL(A, M)} aktarabilirsiniz`,
       warning: (Z, A, M) => `${CUR(A)} ${TL(A, M)} limitinizin ${CUR(A)}${Z} kısmı kalmış bulunmaktadır`
@@ -213,6 +212,7 @@ export default {
       address: `Hedef Adresi`,
       balance: (name, balance) => `Geçerli ${name} bakiyeniz ${typeof balance === 'string' ? balance.slice(0,8) :''}`,
       tokenAddress: (name) => `${name} Adresi`,
+      txCost: (ethCost, currencyCost) => `İşlem maliyeti: ${ethCost} ETH (${currencyCost}) 'dir` ,
     },
     panelHeaders: [
       `Cüzdan Adresi`,

--- a/packages/language/languages/vi.ts
+++ b/packages/language/languages/vi.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `Chuyển hết`,
       balance: Y => `Số dư ETH hiện tại của bạn là ${typeof Y === 'string' ? Y.slice(0,8) :''}`,
       ethAddress: `Địa chỉ Ethereum`,
-      txCost: (B, A) => `Chi phí giao dịch hiện tại là ${CUR(A)}${B}`,
       transferLowercase: `Chuyển tiền Eth`,
       note: (A, M) => `Lưu ý: bạn chỉ có thể chuyển ${CUR(A)} ${TL(A, M)} mỗi tuần trên Lndr`,
       warning: (Z, A, M) => `Bạn còn lại ${CUR(A)}${Z} trong hạn mức ${CUR(A)} ${TL(A, M)}`,
@@ -213,6 +212,7 @@ export default {
       address: `Địa chỉ Gửi đến`,
       balance: (name, balance) => `Số dư ${name} hiện tại là ${typeof balance === 'string' ? balance.slice(0,8) :''}`,
       tokenAddress: (name) => `Địa chỉ ${name}`,
+      txCost: (ethCost, currencyCost) => `Chi phí giao dịch: ${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `Wallet Địa chỉ`,

--- a/packages/language/languages/zh-CN.ts
+++ b/packages/language/languages/zh-CN.ts
@@ -199,7 +199,6 @@ export default {
       transferAll: `全部转移`,
       balance: Y => `您当前的以太坊余额为 ${typeof Y === 'string' ? Y.slice(0,8) :''}`,
       ethAddress: `以太坊地址`,
-      txCost: (B, A) => `当前交易成本为${CUR(A)}${B}`,
       transferLowercase: `转账以太坊`,
       note: (A, M) => `请注意：您每周只能从Lndr转出${CUR(A)} ${TL(A, M)}`,
       warning: (Z, A, M) => `您在每周限额${CUR(A)} ${TL(A, M)}中还剩余${CUR(A)}${Z}`,
@@ -213,6 +212,7 @@ export default {
       address: `目标地址`,
       balance: (name, balance) => `您当前的${name}余额为${typeof balance === 'string' ? balance.slice(0,8) :''}`,
       tokenAddress: (name) => `${name}地址`,
+      txCost: (ethCost, currencyCost) => `交易成本：${ethCost} ETH (${currencyCost})`,
     },
     panelHeaders: [
       `钱包地址`,

--- a/packages/ui/dialogs/pending-settlement-detail/index.tsx
+++ b/packages/ui/dialogs/pending-settlement-detail/index.tsx
@@ -256,7 +256,7 @@ class PendingSettlementDetail extends Component<Props, State> {
           }
           <View style={{marginBottom: 20}}/>
           {!isPayee && <Text style={[formStyle.smallText, formStyle.spaceTop, formStyle.center]}>{accountManagement.sendEth.warning(this.getLimit(), primaryCurrency, transferLimitLevel)}</Text>}
-          {!isPayee && <Text style={[accountStyle.txCost, formStyle.spaceBottom, {marginLeft: '2%'}]}>{accountManagement.sendEth.txCost(ethCostFormatted, currencyCostFormatted)}</Text>}
+          {!isPayee && <Text style={[accountStyle.txCost, formStyle.spaceBottom, {marginLeft: '2%'}]}>{accountManagement.sendERC20.txCost(ethCostFormatted, currencyCostFormatted)}</Text>}
           {confirmationError && <Text style={[formStyle.warningText, {alignSelf: 'center'}]}>{confirmationError}</Text>}
           {this.showButtons()}
           <View style={general.spaceBelow}/>

--- a/packages/ui/dialogs/pending-settlement-detail/index.tsx
+++ b/packages/ui/dialogs/pending-settlement-detail/index.tsx
@@ -256,7 +256,7 @@ class PendingSettlementDetail extends Component<Props, State> {
           }
           <View style={{marginBottom: 20}}/>
           {!isPayee && <Text style={[formStyle.smallText, formStyle.spaceTop, formStyle.center]}>{accountManagement.sendEth.warning(this.getLimit(), primaryCurrency, transferLimitLevel)}</Text>}
-          {!isPayee && <Text style={[accountStyle.txCost, formStyle.spaceBottom, {marginLeft: '2%'}]}>{accountManagement.sendEth.txCost(ethCost, formatCommaDecimal(currencyCost), primaryCurrency)}</Text>}
+          {!isPayee && <Text style={[accountStyle.txCost, formStyle.spaceBottom, {marginLeft: '2%'}]}>{accountManagement.sendEth.txCost(ethCost, currencyCost)}</Text>}
           {confirmationError && <Text style={[formStyle.warningText, {alignSelf: 'center'}]}>{confirmationError}</Text>}
           {this.showButtons()}
           <View style={general.spaceBelow}/>

--- a/packages/ui/dialogs/pending-settlement-detail/index.tsx
+++ b/packages/ui/dialogs/pending-settlement-detail/index.tsx
@@ -34,7 +34,7 @@ const {
 
 import { getUser, settlerIsMe, getEthExchange, getWeeklyEthTotal, calculateBalance, getUcacCurrency, getPrimaryCurrency,
   getFriendFromAddress } from 'reducers/app'
-import { addDebt, rejectPendingSettlement, getTransactionCost, getTransferLimitLevel, exceedsTransferLimit } from 'actions'
+import { addDebt, rejectPendingSettlement, getTransactionCosts, getTransferLimitLevel, exceedsTransferLimit } from 'actions'
 import { connect } from 'react-redux'
 
 const loadingContext = new LoadingContext()
@@ -63,7 +63,8 @@ interface Props {
 }
 
 interface State {
-  txCost: string
+  currencyCost: string
+  ethCost: string
   pic?: string
   confirmationError?: string
   transferLimitLevel: string
@@ -75,7 +76,8 @@ class PendingSettlementDetail extends Component<Props, State> {
     super(props)
     this.state = {
       token: undefined,
-      txCost: '0.00',
+      currencyCost: '0.00',
+      ethCost: '0.00',
       transferLimitLevel: TRANSFER_LIMIT_STANDARD
     }
   }
@@ -87,8 +89,8 @@ class PendingSettlementDetail extends Component<Props, State> {
     const pendingSettlement = this.getPendingSettlement()
     const settlementType = pendingSettlement.settlementCurrency
 
-    const txCost = await getTransactionCost(settlementType, primaryCurrency)
-    this.setState({ transferLimitLevel, txCost })
+    const { currencyCost, ethCost } = await getTransactionCosts(settlementType, primaryCurrency)
+    this.setState({ transferLimitLevel, currencyCost, ethCost })
 
     if (isERC20Settlement(settlementType)) {
       this.setState({ token: getERC20_token(settlementType) })
@@ -224,7 +226,7 @@ class PendingSettlementDetail extends Component<Props, State> {
   }
 
   render() {
-    const { txCost, confirmationError, transferLimitLevel } = this.state
+    const { currencyCost, ethCost, confirmationError, transferLimitLevel } = this.state
     const { user, primaryCurrency } = this.props
     const pendingSettlement = this.getPendingSettlement()
     const isPayee = (user.address === pendingSettlement.debtorAddress)
@@ -254,7 +256,7 @@ class PendingSettlementDetail extends Component<Props, State> {
           }
           <View style={{marginBottom: 20}}/>
           {!isPayee && <Text style={[formStyle.smallText, formStyle.spaceTop, formStyle.center]}>{accountManagement.sendEth.warning(this.getLimit(), primaryCurrency, transferLimitLevel)}</Text>}
-          {!isPayee && <Text style={[accountStyle.txCost, formStyle.spaceBottom, {marginLeft: '2%'}]}>{accountManagement.sendEth.txCost(formatCommaDecimal(txCost), primaryCurrency)}</Text>}
+          {!isPayee && <Text style={[accountStyle.txCost, formStyle.spaceBottom, {marginLeft: '2%'}]}>{accountManagement.sendEth.txCost(ethCost, formatCommaDecimal(currencyCost), primaryCurrency)}</Text>}
           {confirmationError && <Text style={[formStyle.warningText, {alignSelf: 'center'}]}>{confirmationError}</Text>}
           {this.showButtons()}
           <View style={general.spaceBelow}/>

--- a/packages/ui/dialogs/pending-settlement-detail/index.tsx
+++ b/packages/ui/dialogs/pending-settlement-detail/index.tsx
@@ -5,6 +5,7 @@ import { Text, View, Image, ScrollView } from 'react-native'
 import { getStore } from 'reducers/app'
 import { getResetAction } from 'reducers/nav'
 
+import { defaultTransactionCosts, TransactionCosts } from 'credit-protocol'
 import { UserData } from 'lndr/user'
 import { currencyFormats, formatCommaDecimal, formatEthRemaining, isERC20Settlement, formatSettlementCurrencyAmount, isEthSettlement } from 'lndr/format'
 import PendingUnilateral from 'lndr/pending-unilateral'
@@ -63,7 +64,7 @@ interface Props {
 }
 
 interface State {
-  transactionCosts: any
+  transactionCosts: TransactionCosts
   pic?: string
   confirmationError?: string
   transferLimitLevel: string
@@ -75,7 +76,7 @@ class PendingSettlementDetail extends Component<Props, State> {
     super(props)
     this.state = {
       token: undefined,
-      transactionCosts: {},
+      transactionCosts: defaultTransactionCosts(),
       transferLimitLevel: TRANSFER_LIMIT_STANDARD
     }
   }

--- a/packages/ui/dialogs/pending-settlement-detail/index.tsx
+++ b/packages/ui/dialogs/pending-settlement-detail/index.tsx
@@ -63,8 +63,7 @@ interface Props {
 }
 
 interface State {
-  currencyCost: string
-  ethCost: string
+  transactionCosts: any
   pic?: string
   confirmationError?: string
   transferLimitLevel: string
@@ -76,8 +75,7 @@ class PendingSettlementDetail extends Component<Props, State> {
     super(props)
     this.state = {
       token: undefined,
-      currencyCost: '0.00',
-      ethCost: '0.00',
+      transactionCosts: {},
       transferLimitLevel: TRANSFER_LIMIT_STANDARD
     }
   }
@@ -89,8 +87,8 @@ class PendingSettlementDetail extends Component<Props, State> {
     const pendingSettlement = this.getPendingSettlement()
     const settlementType = pendingSettlement.settlementCurrency
 
-    const { currencyCost, ethCost } = await getTransactionCosts(settlementType, primaryCurrency)
-    this.setState({ transferLimitLevel, currencyCost, ethCost })
+    const transactionCosts = await getTransactionCosts(settlementType, primaryCurrency)
+    this.setState({ transferLimitLevel, transactionCosts })
 
     if (isERC20Settlement(settlementType)) {
       this.setState({ token: getERC20_token(settlementType) })
@@ -226,7 +224,8 @@ class PendingSettlementDetail extends Component<Props, State> {
   }
 
   render() {
-    const { currencyCost, ethCost, confirmationError, transferLimitLevel } = this.state
+    const { confirmationError, transferLimitLevel } = this.state
+    const { currencyCostFormatted, ethCostFormatted } = this.state.transactionCosts
     const { user, primaryCurrency } = this.props
     const pendingSettlement = this.getPendingSettlement()
     const isPayee = (user.address === pendingSettlement.debtorAddress)
@@ -256,7 +255,7 @@ class PendingSettlementDetail extends Component<Props, State> {
           }
           <View style={{marginBottom: 20}}/>
           {!isPayee && <Text style={[formStyle.smallText, formStyle.spaceTop, formStyle.center]}>{accountManagement.sendEth.warning(this.getLimit(), primaryCurrency, transferLimitLevel)}</Text>}
-          {!isPayee && <Text style={[accountStyle.txCost, formStyle.spaceBottom, {marginLeft: '2%'}]}>{accountManagement.sendEth.txCost(ethCost, currencyCost)}</Text>}
+          {!isPayee && <Text style={[accountStyle.txCost, formStyle.spaceBottom, {marginLeft: '2%'}]}>{accountManagement.sendEth.txCost(ethCostFormatted, currencyCostFormatted)}</Text>}
           {confirmationError && <Text style={[formStyle.warningText, {alignSelf: 'center'}]}>{confirmationError}</Text>}
           {this.showButtons()}
           <View style={general.spaceBelow}/>

--- a/packages/ui/dialogs/settlement/index.tsx
+++ b/packages/ui/dialogs/settlement/index.tsx
@@ -80,19 +80,16 @@ interface Props {
 
 interface State {
   amount?: string
-  formInputError?: string
   balance: number
   direction: string
-  currencyCost: string
-  ethCost: string
-  cryptoCost: string
-  cryptoBalance: string
   pic?: string
   settlementType?: string
   friend: Friend
   fromPayPalRequest?: boolean
   pickerSelection: any
+  settlementInfo: any
   showPicker: boolean
+  transactionCosts: any
   transferLimitLevel: string
 }
 
@@ -102,13 +99,11 @@ class Settlement extends Component<Props, State> {
     this.state = {
       balance: this.getRecentTotal(),
       direction: this.getRecentTotal() > 0 ? 'borrow' : 'lend',
-      currencyCost: '0.00',
-      ethCost: '0.00',
-      cryptoCost: '',
-      cryptoBalance: '',
       friend: new Friend('', ''),
       pickerSelection: { settlementType: undefined, name: settlementManagement.select },
+      settlementInfo: {},
       showPicker: false,
+      transactionCosts: {},
       transferLimitLevel: TRANSFER_LIMIT_STANDARD
     }
 
@@ -169,13 +164,13 @@ class Settlement extends Component<Props, State> {
     const { settlementType } = pickerSelection
 
     if (isSettlementFree(settlementType)) {
-      this.setState({ formInputError: undefined, cryptoCost: '', currencyCost: '0', ethCost: '0', cryptoBalance: '', showPicker: false, pickerSelection, settlementType })
+      this.setState({ settlementInfo: {}, transactionCosts: {}, showPicker: false, pickerSelection, settlementType })
       return
     }
 
-    const { currencyCost, ethCost } = await getTransactionCosts(settlementType, this.props.primaryCurrency)
-    const result = await this.checkSettlementCost(amount === undefined ? '0' : amount, currencyCost, settlementType)
-    this.setState({ ...result, currencyCost, ethCost, showPicker: false, pickerSelection, settlementType })
+    const transactionCosts = await getTransactionCosts(settlementType, this.props.primaryCurrency)
+    const settlementInfo = await this.checkSettlementCost(amount === undefined ? '0' : amount, transactionCosts, settlementType)
+    this.setState({ pickerSelection, settlementInfo, showPicker: false, settlementType, transactionCosts })
   }
 
   getDenomination() {
@@ -192,7 +187,7 @@ class Settlement extends Component<Props, State> {
   }
 
   async submit() {
-    const { amount, direction, formInputError, settlementType } = this.state
+    const { amount, direction, settlementType, settlementInfo: { formInputError } } = this.state
     const { primaryCurrency } = this.props
     const friend = this.props.navigation ? this.props.navigation.state.params.friend : {}
     const denomination = this.getDenomination()
@@ -302,7 +297,7 @@ class Settlement extends Component<Props, State> {
     return exchangeRate
   }
 
-  async checkSettlementCost(amount: string, txCost: string, settlementType?: string) {
+  async checkSettlementCost(amount: string, transactionCosts: any, settlementType?: string) {
     const { ethBalance, ethExchange, ethSentPastWeek, hasPendingTransaction, primaryCurrency } = this.props
     const friend = this.props.navigation ? this.props.navigation.state.params.friend : {}
 
@@ -315,9 +310,9 @@ class Settlement extends Component<Props, State> {
     const cleanAmount = cleanFiatAmount(amount)
 
     // Check that we have enough Eth to cover Eth costs
-    const ethExchangeRate = Number(ethExchange(primaryCurrency))
-    let totalEthCost = Number(txCost) / ethExchangeRate
+    let totalEthCost = transactionCosts.ethCost
     if (isEthSettlement(settlementType)) {
+      const ethExchangeRate = Number(ethExchange(primaryCurrency))
       totalEthCost += cleanAmount / ethExchangeRate
     }
 
@@ -325,27 +320,33 @@ class Settlement extends Component<Props, State> {
         formInputError = accountManagement.sendEth.error.insufficient
     }
 
-    let cryptoCostString = String(totalEthCost)
-    let cryptoBalanceString = ethBalance
+    let settlementCost, settlementBalance
 
+    const exchangeRate = this.calculateExchangeRate(cleanAmount, settlementType)
     if (settlementType && isERC20Settlement(settlementType)) {
       // Check we have enough non-Eth crypto (doesn't include transaction cost)
-      const exchangeRate = this.calculateExchangeRate(cleanAmount, settlementType)
-      const cryptoCost = cleanAmount / exchangeRate
-      cryptoCostString = String(cryptoCost)
+      settlementCost = cleanAmount / exchangeRate
 
       const token = getERC20_token(settlementType)
-      cryptoBalanceString = await token.getBalance(this.props.user.address)
+      settlementBalance = Number(await token.getBalance(this.props.user.address))
 
-      if (!formInputError && !this.isPayee() && (cryptoCost > Number(cryptoBalanceString))) {
+      if (!formInputError && !this.isPayee() && (settlementCost > settlementBalance)) {
         formInputError = accountManagement.sendERC20.error.insufficient(token.tokenName)
       }
+    } else {
+      settlementCost = totalEthCost
+      settlementBalance = Number(ethBalance)
     }
 
     if (!formInputError && !this.isPayee() && exceedsTransferLimit(Number(cleanAmount), this.state.transferLimitLevel, ethExchange(primaryCurrency), ethSentPastWeek))
       formInputError = accountManagement.sendEth.error.limitExceeded(primaryCurrency, this.state.transferLimitLevel)
 
-    return { formInputError, cryptoCost: cryptoCostString, cryptoBalance: cryptoBalanceString }
+    return { formInputError,
+      settlementBalance,
+      settlementBalancePrimary: formatExchangeCurrency(settlementBalance, String(exchangeRate), primaryCurrency),
+      settlementCost,
+      settlementCostFormatted: formatCommaDecimal(settlementCost.slice(0, 6))
+    }
   }
 
   getLimit() {
@@ -354,8 +355,8 @@ class Settlement extends Component<Props, State> {
   }
 
   async updateAmount(amount: string) {
-    const result = await this.checkSettlementCost(amount, this.state.currencyCost, this.state.settlementType)
-    this.setState({ amount: amountFormat(amount, this.props.primaryCurrency, false), ...result })
+    const settlementInfo = await this.checkSettlementCost(amount, this.state.transactionCosts, this.state.settlementType)
+    this.setState({ amount: amountFormat(amount, this.props.primaryCurrency, false), settlementInfo })
   }
 
   blurCurrencyFormat() {
@@ -407,7 +408,7 @@ class Settlement extends Component<Props, State> {
   }
 
   renderPaymentButton() {
-    const { amount, direction, formInputError, pickerSelection, settlementType } = this.state
+    const { amount, direction, pickerSelection, settlementInfo: { formInputError }, settlementType } = this.state
     if (typeof amount !== 'string')
       return null
 
@@ -467,12 +468,13 @@ class Settlement extends Component<Props, State> {
   }
 
   render() {
-    const { amount, balance, formInputError, pic, cryptoCost, friend, currencyCost, ethCost, fromPayPalRequest, pickerSelection, settlementType } = this.state
+    const { amount, balance, pic, friend, fromPayPalRequest, pickerSelection, settlementType } = this.state
+    const { currencyCostFormatted, ethCostFormatted} = this.state.transactionCosts
+    const { formInputError, settlementBalance, settlementBalanceFormatted, settlementCost, settlementCostFormatted } = this.state.settlementInfo
     const { primaryCurrency } = this.props
     const imageSource = pic ? { uri: pic } : require('images/person-outline-dark.png')
     const vertOffset = (Platform.OS === 'android') ? -300 : 20
 
-    const cryptoBalance = isEthSettlement(settlementType) ? this.props.ethBalance : this.state.cryptoBalance
     const paymentButton = this.renderPaymentButton()
     const cleanAmount = cleanFiatAmount(String(amount))
     const exchangeRate = this.calculateExchangeRate(cleanAmount, settlementType)
@@ -501,13 +503,13 @@ class Settlement extends Component<Props, State> {
 
               <View style={general.centeredColumn}>
                 { (settlementType && isERC20) ? <View style={[accountStyle.balanceRow, {marginTop: 20}]}>
-                  <Text style={[accountStyle.balance, {marginLeft: '2%'}]}>{accountManagement.cryptoBalance.display(settlementType.toUpperCase(), formatCommaDecimal(cryptoBalance))}</Text>
+                  <Text style={[accountStyle.balance, {marginLeft: '2%'}]}>{accountManagement.cryptoBalance.display(settlementType.toUpperCase(), formatCommaDecimal(settlementBalance))}</Text>
                   <Button alternate blackText narrow arrow small onPress={() => {this.props.navigation.navigate('MyAccount')}}
-                    text={formatExchangeCurrency(cryptoBalance, String(exchangeRate), primaryCurrency)}
+                    text={settlementBalanceFormatted}
                     containerStyle={{marginTop: -6}}
                   />
                 </View> : null }
-                { isERC20 ? <Text style={[accountStyle.txCost, {marginLeft: '2%'}]}>{accountManagement.sendEth.txCost(ethCost, currencyCost)}</Text> : null }
+                { isERC20 ? <Text style={[accountStyle.txCost, {marginLeft: '2%'}]}>{accountManagement.sendEth.txCost(ethCostFormatted, currencyCostFormatted)}</Text> : null }
                 { (isERC20 && balance > 0) ? <Text style={[formStyle.smallText, formStyle.spaceTop, formStyle.center]}>{accountManagement.sendEth.warning(this.getLimit(), primaryCurrency, this.state.transferLimitLevel)}</Text> : null}
                 <Text style={formStyle.titleLarge}>{debtManagement.fields.settlementAmount}</Text>
                 { isERC20 ? <TextInput
@@ -526,7 +528,7 @@ class Settlement extends Component<Props, State> {
             { isPayPalSettlement(settlementType) ? <View style={general.centeredColumn}>
               <Button alternate small arrow onPress={this.payPalFeesAlert} text={payPalLanguage.feesNotification} />
             </View> : null }
-            { settlementType && isERC20 && cryptoCost !== '' && <Text style={[formStyle.smallText, formStyle.spaceTop, formStyle.center]}>{`${formatCommaDecimal(cryptoCost.slice(0, 6))} ${settlementType.toUpperCase()}`}</Text>}
+            { settlementType && isERC20 && settlementCostFormatted !== '' && <Text style={[formStyle.smallText, formStyle.spaceTop, formStyle.center]}>{`${settlementCostFormatted} ${settlementType.toUpperCase()}`}</Text>}
             { !!formInputError && <Text style={[formStyle.warningText, {alignSelf: 'center', marginHorizontal: 15}]}>{formInputError}</Text>}
             { paymentButton }
             { !!fromPayPalRequest ? <Button danger round containerStyle={{width: '80%'}} onPress={this.rejectPayPalRequest} text={pendingTransactionsLanguage.rejectRequest} /> : null }

--- a/packages/ui/dialogs/settlement/index.tsx
+++ b/packages/ui/dialogs/settlement/index.tsx
@@ -497,6 +497,8 @@ class Settlement extends Component<Props, State> {
     const exchangeRate = this.calculateExchangeRate(cleanAmount, settlementType)
     const isERC20 = isEthSettlement(settlementType) || isERC20Settlement(settlementType)
 
+    const settlementText = (settlementType && isERC20 && settlementCostFormatted !== '') ? `${settlementCostFormatted} ${settlementType.toUpperCase()}` : amount
+
     return <View style={general.whiteFlex}>
       <View style={general.view}>
         <DashboardShell text={debtManagement.settleUpLower} navigation={this.props.navigation} />
@@ -533,19 +535,19 @@ class Settlement extends Component<Props, State> {
                   style={[formStyle.jumboInput, formStyle.settleAmount]}
                   placeholder={`${currencySymbols(primaryCurrency)}0`}
                   placeholderTextColor='black'
-                  value={amount}
+                  value={settlementText}
                   maxLength={11}
                   underlineColorAndroid='transparent'
                   keyboardType='numeric'
                   onChangeText={this.updateAmount}
                   onBlur={this.blurCurrencyFormat}
-                /> : <Text style={formStyle.jumboInput}>{amount}</Text>}
+                /> : <Text style={formStyle.jumboInput}>{settlementText}</Text>}
               </View>
             </View>
             { isPayPalSettlement(settlementType) ? <View style={general.centeredColumn}>
               <Button alternate small arrow onPress={this.payPalFeesAlert} text={payPalLanguage.feesNotification} />
             </View> : null }
-            { settlementType && isERC20 && settlementCostFormatted !== '' && <Text style={[formStyle.smallText, formStyle.spaceTop, formStyle.center]}>{`${settlementCostFormatted} ${settlementType.toUpperCase()}`}</Text>}
+            { settlementType && isERC20 && settlementCostFormatted !== '' && <Text style={[formStyle.smallText, formStyle.spaceVertical, formStyle.center]}>{amount}</Text>}
             { !!formInputError && <Text style={[formStyle.warningText, {alignSelf: 'center', marginHorizontal: 15}]}>{formInputError}</Text>}
             { paymentButton }
             { !!fromPayPalRequest ? <Button danger round containerStyle={{width: '80%'}} onPress={this.rejectPayPalRequest} text={pendingTransactionsLanguage.rejectRequest} /> : null }

--- a/packages/ui/dialogs/settlement/index.tsx
+++ b/packages/ui/dialogs/settlement/index.tsx
@@ -526,7 +526,7 @@ class Settlement extends Component<Props, State> {
                     containerStyle={{marginTop: -6}}
                   />
                 </View> : null }
-                { isERC20 ? <Text style={[accountStyle.txCost, {marginLeft: '2%'}]}>{accountManagement.sendEth.txCost(ethCostFormatted, currencyCostFormatted)}</Text> : null }
+                { isERC20 ? <Text style={[accountStyle.txCost, {marginLeft: '2%'}]}>{accountManagement.sendERC20.txCost(ethCostFormatted, currencyCostFormatted)}</Text> : null }
                 { (isERC20 && balance > 0) ? <Text style={[formStyle.smallText, formStyle.spaceTop, formStyle.center]}>{accountManagement.sendEth.warning(this.getLimit(), primaryCurrency, this.state.transferLimitLevel)}</Text> : null}
                 <Text style={formStyle.titleLarge}>{debtManagement.fields.settlementAmount}</Text>
                 { isERC20 ? <TextInput

--- a/packages/ui/dialogs/settlement/index.tsx
+++ b/packages/ui/dialogs/settlement/index.tsx
@@ -507,7 +507,7 @@ class Settlement extends Component<Props, State> {
                     containerStyle={{marginTop: -6}}
                   />
                 </View> : null }
-                { isERC20 ? <Text style={[accountStyle.txCost, {marginLeft: '2%'}]}>{accountManagement.sendEth.txCost(ethCost, formatCommaDecimal(currencyCost), this.props.primaryCurrency)}</Text> : null }
+                { isERC20 ? <Text style={[accountStyle.txCost, {marginLeft: '2%'}]}>{accountManagement.sendEth.txCost(ethCost, currencyCost)}</Text> : null }
                 { (isERC20 && balance > 0) ? <Text style={[formStyle.smallText, formStyle.spaceTop, formStyle.center]}>{accountManagement.sendEth.warning(this.getLimit(), primaryCurrency, this.state.transferLimitLevel)}</Text> : null}
                 <Text style={formStyle.titleLarge}>{debtManagement.fields.settlementAmount}</Text>
                 { isERC20 ? <TextInput

--- a/packages/ui/dialogs/settlement/index.tsx
+++ b/packages/ui/dialogs/settlement/index.tsx
@@ -345,7 +345,7 @@ class Settlement extends Component<Props, State> {
       settlementBalance,
       settlementBalancePrimary: formatExchangeCurrency(settlementBalance, String(exchangeRate), primaryCurrency),
       settlementCost,
-      settlementCostFormatted: formatCommaDecimal(settlementCost.slice(0, 6))
+      settlementCostFormatted: formatCommaDecimal(String(settlementCost).slice(0, 6))
     }
   }
 

--- a/packages/ui/dialogs/transfer-erc20/index.tsx
+++ b/packages/ui/dialogs/transfer-erc20/index.tsx
@@ -43,8 +43,7 @@ interface State {
   formInputError?: string
   token?: ERC20_Token
   tokenBalance: string
-  currencyCost: string
-  ethCost: string
+  transactionCosts: any
 }
 
 class TransferERC20 extends Component<Props, State> {
@@ -53,8 +52,7 @@ class TransferERC20 extends Component<Props, State> {
     this.state = {
       token: undefined,
       tokenBalance: '0.00',
-      currencyCost: '0.00',
-      ethCost: '0.00'
+      transactionCosts: {},
     }
   }
 
@@ -62,9 +60,9 @@ class TransferERC20 extends Component<Props, State> {
     const { primaryCurrency, user } = this.props
     const token = this.props.navigation ? this.props.navigation.state.params.token : undefined
     if (token) {
-      const { currencyCost, ethCost } = await getTransactionCosts(token.tokenName, primaryCurrency)
+      const transactionCosts = await getTransactionCosts(token.tokenName, primaryCurrency)
       const tokenBalance = await token.getBalance(user.address as string)
-      this.setState({ token, currencyCost, ethCost, tokenBalance })
+      this.setState({ token, transactionCosts, tokenBalance })
     }
   }
 
@@ -130,7 +128,8 @@ class TransferERC20 extends Component<Props, State> {
   }
 
   render() {
-    const { amount, destinationAddress, formInputError, token, tokenBalance, currencyCost, ethCost } = this.state
+    const { amount, destinationAddress, formInputError, token, tokenBalance } = this.state
+    const { currencyCostFormatted, ethCostFormatted} = this.state.transactionCosts
     const { primaryCurrency } = this.props
 
     const tokenName = (token) ? token.tokenName : ''
@@ -172,7 +171,7 @@ class TransferERC20 extends Component<Props, State> {
                     onChangeText={amount => this.setState({ amount: this.setAmount(amount) })}
                   />
                 </View>
-                <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(ethCost, currencyCost)}</Text>
+                <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(ethCostFormatted, currencyCostFormatted)}</Text>
               </View>
             </View>
             { !!formInputError && <Text style={formStyle.warningText}>{formInputError}</Text>}

--- a/packages/ui/dialogs/transfer-erc20/index.tsx
+++ b/packages/ui/dialogs/transfer-erc20/index.tsx
@@ -171,7 +171,7 @@ class TransferERC20 extends Component<Props, State> {
                     onChangeText={amount => this.setState({ amount: this.setAmount(amount) })}
                   />
                 </View>
-                <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(ethCostFormatted, currencyCostFormatted)}</Text>
+                <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendERC20.txCost(ethCostFormatted, currencyCostFormatted)}</Text>
               </View>
             </View>
             { !!formInputError && <Text style={formStyle.warningText}>{formInputError}</Text>}

--- a/packages/ui/dialogs/transfer-erc20/index.tsx
+++ b/packages/ui/dialogs/transfer-erc20/index.tsx
@@ -172,7 +172,7 @@ class TransferERC20 extends Component<Props, State> {
                     onChangeText={amount => this.setState({ amount: this.setAmount(amount) })}
                   />
                 </View>
-                <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(ethCost, formatCommaDecimal(currencyCost), primaryCurrency)}</Text>
+                <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(ethCost, currencyCost)}</Text>
               </View>
             </View>
             { !!formInputError && <Text style={formStyle.warningText}>{formInputError}</Text>}

--- a/packages/ui/dialogs/transfer-erc20/index.tsx
+++ b/packages/ui/dialogs/transfer-erc20/index.tsx
@@ -2,8 +2,12 @@ import React, { Component } from 'react'
 
 import { Text, TextInput, View, ScrollView, KeyboardAvoidingView, Platform } from 'react-native'
 import firebase from 'react-native-firebase'
+import { connect } from 'react-redux'
 
+import { getUser, getPrimaryCurrency } from 'reducers/app'
 import { getResetAction } from 'reducers/nav'
+import { getTransactionCosts, sendERC20 } from 'actions'
+import { defaultTransactionCosts, TransactionCosts } from 'credit-protocol'
 
 import { UserData } from 'lndr/user'
 import { cryptoAmount, formatCommaDecimal, isEthAddress } from 'lndr/format'
@@ -23,10 +27,6 @@ const {
   accountManagement
 } = language
 
-import { getUser, getPrimaryCurrency } from 'reducers/app'
-import { getTransactionCosts, sendERC20 } from 'actions'
-import { connect } from 'react-redux'
-
 const loadingContext = new LoadingContext()
 
 interface Props {
@@ -43,7 +43,7 @@ interface State {
   formInputError?: string
   token?: ERC20_Token
   tokenBalance: string
-  transactionCosts: any
+  transactionCosts: TransactionCosts
 }
 
 class TransferERC20 extends Component<Props, State> {
@@ -52,7 +52,7 @@ class TransferERC20 extends Component<Props, State> {
     this.state = {
       token: undefined,
       tokenBalance: '0.00',
-      transactionCosts: {},
+      transactionCosts: defaultTransactionCosts(),
     }
   }
 

--- a/packages/ui/dialogs/transfer-erc20/index.tsx
+++ b/packages/ui/dialogs/transfer-erc20/index.tsx
@@ -24,7 +24,7 @@ const {
 } = language
 
 import { getUser, getPrimaryCurrency } from 'reducers/app'
-import { getTransactionCost, sendERC20 } from 'actions'
+import { getTransactionCosts, sendERC20 } from 'actions'
 import { connect } from 'react-redux'
 
 const loadingContext = new LoadingContext()
@@ -43,7 +43,8 @@ interface State {
   formInputError?: string
   token?: ERC20_Token
   tokenBalance: string
-  txCost: string
+  currencyCost: string
+  ethCost: string
 }
 
 class TransferERC20 extends Component<Props, State> {
@@ -52,7 +53,8 @@ class TransferERC20 extends Component<Props, State> {
     this.state = {
       token: undefined,
       tokenBalance: '0.00',
-      txCost: '0.00'
+      currencyCost: '0.00',
+      ethCost: '0.00'
     }
   }
 
@@ -60,9 +62,9 @@ class TransferERC20 extends Component<Props, State> {
     const { primaryCurrency, user } = this.props
     const token = this.props.navigation ? this.props.navigation.state.params.token : undefined
     if (token) {
-      const txCost = await getTransactionCost(token.tokenName, primaryCurrency)
+      const { currencyCost, ethCost } = await getTransactionCosts(token.tokenName, primaryCurrency)
       const tokenBalance = await token.getBalance(user.address as string)
-      this.setState({ token, txCost, tokenBalance })
+      this.setState({ token, currencyCost, ethCost, tokenBalance })
     }
   }
 
@@ -128,7 +130,7 @@ class TransferERC20 extends Component<Props, State> {
   }
 
   render() {
-    const { amount, destinationAddress, formInputError, token, tokenBalance, txCost } = this.state
+    const { amount, destinationAddress, formInputError, token, tokenBalance, currencyCost, ethCost } = this.state
     const { primaryCurrency } = this.props
 
     const tokenName = (token) ? token.tokenName : ''
@@ -170,7 +172,7 @@ class TransferERC20 extends Component<Props, State> {
                     onChangeText={amount => this.setState({ amount: this.setAmount(amount) })}
                   />
                 </View>
-                <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(formatCommaDecimal(txCost), primaryCurrency)}</Text>
+                <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(ethCost, formatCommaDecimal(currencyCost), primaryCurrency)}</Text>
               </View>
             </View>
             { !!formInputError && <Text style={formStyle.warningText}>{formInputError}</Text>}

--- a/packages/ui/dialogs/transfer-eth/index.tsx
+++ b/packages/ui/dialogs/transfer-eth/index.tsx
@@ -6,6 +6,7 @@ import firebase from 'react-native-firebase'
 import { getStore } from 'reducers/app'
 import { getResetAction } from 'reducers/nav'
 
+import { defaultTransactionCosts, TransactionCosts } from 'credit-protocol'
 import { UserData } from 'lndr/user'
 import { cryptoAmount, isEthAddress, formatCommaDecimal, formatEthRemaining } from 'lndr/format'
 import { currencySymbols, isCommaDecimal, transferLimits, TRANSFER_LIMIT_STANDARD } from 'lndr/currencies'
@@ -45,7 +46,7 @@ interface State {
   amount?: string
   formInputError?: string
   address?: string
-  transactionCosts: any
+  transactionCosts: TransactionCosts
   transferLimitLevel: string
 }
 
@@ -53,7 +54,7 @@ class TransferEth extends Component<Props, State> {
   constructor(props) {
     super(props)
     this.state = {
-      transactionCosts: {},
+      transactionCosts: defaultTransactionCosts(),
       transferLimitLevel: TRANSFER_LIMIT_STANDARD
     }
 

--- a/packages/ui/dialogs/transfer-eth/index.tsx
+++ b/packages/ui/dialogs/transfer-eth/index.tsx
@@ -201,7 +201,7 @@ class TransferEth extends Component<Props, State> {
                 </View>
               </View>
               <Text style={[formStyle.smallText, formStyle.center, formStyle.spaceTopS]}>{`${currencySymbols(primaryCurrency)}${this.toFiat(amount, ethExchange(primaryCurrency))}`}</Text>
-              <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(ethCost, formatCommaDecimal(currencyCost), primaryCurrency)}</Text>
+              <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(ethCost, currencyCost)}</Text>
             </View>
             { formInputError && <Text style={[formStyle.warningText, {alignSelf: 'center'}]}>{formInputError}</Text>}
             <Button large round wide onPress={() => this.submit()} text={accountManagement.sendEth.transfer} />

--- a/packages/ui/dialogs/transfer-eth/index.tsx
+++ b/packages/ui/dialogs/transfer-eth/index.tsx
@@ -25,7 +25,7 @@ const {
 } = language
 
 import { getUser, getEthBalance, getEthExchange, getWeeklyEthTotal, getPrimaryCurrency } from 'reducers/app'
-import { sendEth, getTransactionCost, getTransferLimitLevel, exceedsTransferLimit } from 'actions'
+import { sendEth, getTransactionCosts, getTransferLimitLevel, exceedsTransferLimit } from 'actions'
 import { connect } from 'react-redux'
 
 const sendingEthLoader = new LoadingContext()
@@ -45,7 +45,8 @@ interface State {
   amount?: string
   formInputError?: string
   address?: string
-  txCost: string
+  currencyCost: string
+  ethCost: string
   transferLimitLevel: string
 }
 
@@ -53,7 +54,8 @@ class TransferEth extends Component<Props, State> {
   constructor(props) {
     super(props)
     this.state = {
-      txCost: '0.00',
+      currencyCost: '0.00',
+      ethCost: '0.00',
       transferLimitLevel: TRANSFER_LIMIT_STANDARD
     }
 
@@ -62,10 +64,10 @@ class TransferEth extends Component<Props, State> {
 
   async componentWillMount() {
     const { primaryCurrency, user } = this.props
-    const txCost = await getTransactionCost('eth', primaryCurrency)
+    const { ethCost, currencyCost } = await getTransactionCosts('eth', primaryCurrency)
     const transferLimitLevel = await getTransferLimitLevel(user.address, this.props.getStore())
 
-    this.setState({ txCost, transferLimitLevel })
+    this.setState({ ethCost, currencyCost, transferLimitLevel })
   }
 
   componentDidMount( ) {
@@ -156,7 +158,7 @@ class TransferEth extends Component<Props, State> {
   }
 
   render() {
-    const { amount, address, txCost, formInputError, transferLimitLevel } = this.state
+    const { amount, address, currencyCost, ethCost, formInputError, transferLimitLevel } = this.state
     const { ethBalance, ethExchange, primaryCurrency } = this.props
 
     return <ScrollView style={general.whiteFlex}>
@@ -199,7 +201,7 @@ class TransferEth extends Component<Props, State> {
                 </View>
               </View>
               <Text style={[formStyle.smallText, formStyle.center, formStyle.spaceTopS]}>{`${currencySymbols(primaryCurrency)}${this.toFiat(amount, ethExchange(primaryCurrency))}`}</Text>
-              <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(formatCommaDecimal(txCost), primaryCurrency)}</Text>
+              <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(ethCost, formatCommaDecimal(currencyCost), primaryCurrency)}</Text>
             </View>
             { formInputError && <Text style={[formStyle.warningText, {alignSelf: 'center'}]}>{formInputError}</Text>}
             <Button large round wide onPress={() => this.submit()} text={accountManagement.sendEth.transfer} />

--- a/packages/ui/dialogs/transfer-eth/index.tsx
+++ b/packages/ui/dialogs/transfer-eth/index.tsx
@@ -45,8 +45,7 @@ interface State {
   amount?: string
   formInputError?: string
   address?: string
-  currencyCost: string
-  ethCost: string
+  transactionCosts: any
   transferLimitLevel: string
 }
 
@@ -54,8 +53,7 @@ class TransferEth extends Component<Props, State> {
   constructor(props) {
     super(props)
     this.state = {
-      currencyCost: '0.00',
-      ethCost: '0.00',
+      transactionCosts: {},
       transferLimitLevel: TRANSFER_LIMIT_STANDARD
     }
 
@@ -64,10 +62,10 @@ class TransferEth extends Component<Props, State> {
 
   async componentWillMount() {
     const { primaryCurrency, user } = this.props
-    const { ethCost, currencyCost } = await getTransactionCosts('eth', primaryCurrency)
+    const transactionCosts = await getTransactionCosts('eth', primaryCurrency)
     const transferLimitLevel = await getTransferLimitLevel(user.address, this.props.getStore())
 
-    this.setState({ ethCost, currencyCost, transferLimitLevel })
+    this.setState({ transactionCosts, transferLimitLevel })
   }
 
   componentDidMount( ) {
@@ -158,7 +156,8 @@ class TransferEth extends Component<Props, State> {
   }
 
   render() {
-    const { amount, address, currencyCost, ethCost, formInputError, transferLimitLevel } = this.state
+    const { amount, address, formInputError, transferLimitLevel } = this.state
+    const { currencyCostFormatted, ethCostFormatted} = this.state.transactionCosts
     const { ethBalance, ethExchange, primaryCurrency } = this.props
 
     return <ScrollView style={general.whiteFlex}>
@@ -201,7 +200,7 @@ class TransferEth extends Component<Props, State> {
                 </View>
               </View>
               <Text style={[formStyle.smallText, formStyle.center, formStyle.spaceTopS]}>{`${currencySymbols(primaryCurrency)}${this.toFiat(amount, ethExchange(primaryCurrency))}`}</Text>
-              <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(ethCost, currencyCost)}</Text>
+              <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(ethCostFormatted, currencyCostFormatted)}</Text>
             </View>
             { formInputError && <Text style={[formStyle.warningText, {alignSelf: 'center'}]}>{formInputError}</Text>}
             <Button large round wide onPress={() => this.submit()} text={accountManagement.sendEth.transfer} />

--- a/packages/ui/dialogs/transfer-eth/index.tsx
+++ b/packages/ui/dialogs/transfer-eth/index.tsx
@@ -201,7 +201,7 @@ class TransferEth extends Component<Props, State> {
                 </View>
               </View>
               <Text style={[formStyle.smallText, formStyle.center, formStyle.spaceTopS]}>{`${currencySymbols(primaryCurrency)}${this.toFiat(amount, ethExchange(primaryCurrency))}`}</Text>
-              <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendEth.txCost(ethCostFormatted, currencyCostFormatted)}</Text>
+              <Text style={[accountStyle.txCost, formStyle.spaceTop]}>{accountManagement.sendERC20.txCost(ethCostFormatted, currencyCostFormatted)}</Text>
             </View>
             { formInputError && <Text style={[formStyle.warningText, {alignSelf: 'center'}]}>{formInputError}</Text>}
             <Button large round wide onPress={() => this.submit()} text={accountManagement.sendEth.transfer} />


### PR DESCRIPTION
Better late than never! This PR refactors the transaction cost calculations, making it easier to extract different values and show the user transaction costs both in Eth and their primary currency.
<img width="311" alt="image" src="https://user-images.githubusercontent.com/1081476/48588863-af418500-e8ed-11e8-8da4-af2fe3db02eb.png">
<img width="338" alt="image" src="https://user-images.githubusercontent.com/1081476/48588874-b8caed00-e8ed-11e8-8d6f-0b3f9eb4a2d8.png">

Probably needs a good look-through or testing, but in my tests it is looking good!