### PR TITLE
View and copy a friend's wallet address

### DIFF
--- a/packages/ui/dialogs/friend-detail/index.tsx
+++ b/packages/ui/dialogs/friend-detail/index.tsx
@@ -200,7 +200,7 @@ class FriendDetail extends Component<Props, State> {
             <Text style={accountStyle.transactionHeader}>{recentTransactionsLanguage.title}</Text>
             <RecentView friend={friend} navigation={navigation} />
           </View>
-          <View style={formStyle.spaceBottomL}>
+          <View style={[formStyle.spaceTop, formStyle.spaceBottomL]}>
             <TouchableHighlight {...underlayColor} onPress={this.toggleShowWallet}>
               <View style={formStyle.panelHeader}>
                 <Text style={formStyle.panelText}>{'Wallet Address'}</Text>

--- a/packages/ui/dialogs/friend-detail/index.tsx
+++ b/packages/ui/dialogs/friend-detail/index.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 
-import { Text, View, Image, ScrollView, BackHandler, Alert } from 'react-native'
+import { Text, TouchableHighlight, View, Image, ScrollView, BackHandler, Alert } from 'react-native'
 import firebase from 'react-native-firebase'
 
 import Balance from 'lndr/balance'
@@ -21,7 +21,7 @@ import AddDebtButtons from 'ui/components/add-debt-buttons'
 
 import style from 'theme/friend'
 import formStyle from 'theme/form'
-import general from 'theme/general'
+import general, {underlayColor} from 'theme/general'
 import pendingStyle from 'theme/pending'
 import accountStyle from 'theme/account'
 
@@ -61,6 +61,7 @@ interface Props {
 interface State {
   balanceLoaded: boolean
   balance: Balance
+  isWalletShowing: boolean
   friend: Friend
   pic?: string
 }
@@ -71,6 +72,7 @@ class FriendDetail extends Component<Props, State> {
     this.state = {
       balanceLoaded: false,
       balance: new Balance({ relativeToNickname: "", relativeTo: "", amount: 0 }),
+      isWalletShowing: false,
       friend: new Friend('', '')
     }
 
@@ -78,6 +80,7 @@ class FriendDetail extends Component<Props, State> {
     this.goBack = this.goBack.bind(this)
     this.goSettleUp = this.goSettleUp.bind(this)
     this.confirmRemoveFriend = this.confirmRemoveFriend.bind(this)
+    this.toggleShowWallet = this.toggleShowWallet.bind(this)
   }
 
   async componentWillMount() {
@@ -160,6 +163,10 @@ class FriendDetail extends Component<Props, State> {
     navigation.navigate('AddDebt', { friend, direction })
   }
 
+  toggleShowWallet() {
+    this.setState({ isWalletShowing: !this.state.isWalletShowing })
+  }
+
   render() {
     const { friend } = this.state
     const { navigation, primaryCurrency, getPendingFromFriend, copyToClipboard } = this.props
@@ -193,11 +200,19 @@ class FriendDetail extends Component<Props, State> {
             <Text style={accountStyle.transactionHeader}>{recentTransactionsLanguage.title}</Text>
             <RecentView friend={friend} navigation={navigation} />
           </View>
-          <View style={formStyle.spaceHorizontalL}>
-            <Text selectable style={formStyle.displayText}>{`0x${friend.address}`}</Text>
-            <View style={formStyle.horizontalView}>
-              <Button round onPress={() => copyToClipboard(`0x${friend.address}`)} text={copy} />
-            </View>
+          <View style={formStyle.spaceBottomL}>
+            <TouchableHighlight {...underlayColor} onPress={this.toggleShowWallet}>
+              <View style={formStyle.panelHeader}>
+                <Text style={formStyle.panelText}>{'Wallet Address'}</Text>
+                <Image source={require('images/button-arrow.png')} style={this.state.isWalletShowing ? formStyle.panelIconDown : formStyle.panelIconRight} />
+              </View>
+            </TouchableHighlight>
+            {this.state.isWalletShowing && <View style={formStyle.spaceHorizontalL}>
+              <Text selectable style={formStyle.displayText}>{`0x${friend.address}`}</Text>
+              <View style={formStyle.horizontalView}>
+                <Button round onPress={() => copyToClipboard(`0x${friend.address}`)} text={copy} />
+              </View>
+            </View>}
           </View>
           <Button round danger onPress={this.confirmRemoveFriend} text={removeFriendText} containerStyle={style.spaceBottom} />
         </View>

--- a/packages/ui/dialogs/friend-detail/index.tsx
+++ b/packages/ui/dialogs/friend-detail/index.tsx
@@ -20,6 +20,7 @@ import BalanceSection from 'ui/components/balance-section'
 import AddDebtButtons from 'ui/components/add-debt-buttons'
 
 import style from 'theme/friend'
+import formStyle from 'theme/form'
 import general from 'theme/general'
 import pendingStyle from 'theme/pending'
 import accountStyle from 'theme/account'
@@ -32,13 +33,14 @@ const {
   recentTransactionsLanguage,
   removeFriendConfirmationQuestion,
   confirmAccount,
-  cancel
+  cancel,
+  copy
 } = language
 const removeFriendText = language.removeFriend
 
 import { getUser, pendingTransactions, recentTransactions, convertCurrency, calculateBalance,
   getPrimaryCurrency, getPendingFromFriend } from 'reducers/app'
-import { getTwoPartyBalance, removeFriend } from 'actions'
+import { getTwoPartyBalance, removeFriend, copyToClipboard } from 'actions'
 import { connect } from 'react-redux'
 
 const loadingContext = new LoadingContext()
@@ -50,6 +52,7 @@ interface Props {
   pendingTransactions: any
   navigation: any
   calculateBalance: (friend: Friend) => number
+  copyToClipboard: (text: string) => any
   getTwoPartyBalance: (user, friend) => Balance
   primaryCurrency: string
   getPendingFromFriend: (friendNick: string) => any
@@ -159,7 +162,7 @@ class FriendDetail extends Component<Props, State> {
 
   render() {
     const { friend } = this.state
-    const { navigation, primaryCurrency, getPendingFromFriend } = this.props
+    const { navigation, primaryCurrency, getPendingFromFriend, copyToClipboard } = this.props
     const { pic } = this.state
     const imageSource = pic ? { uri: pic } : require('images/person-outline-dark.png')
     const { route } = getPendingFromFriend(friend.nickname)
@@ -190,6 +193,12 @@ class FriendDetail extends Component<Props, State> {
             <Text style={accountStyle.transactionHeader}>{recentTransactionsLanguage.title}</Text>
             <RecentView friend={friend} navigation={navigation} />
           </View>
+          <View style={formStyle.spaceHorizontalL}>
+            <Text selectable style={formStyle.displayText}>{`0x${friend.address}`}</Text>
+            <View style={formStyle.horizontalView}>
+              <Button round onPress={() => copyToClipboard(`0x${friend.address}`)} text={copy} />
+            </View>
+          </View>
           <Button round danger onPress={this.confirmRemoveFriend} text={removeFriendText} containerStyle={style.spaceBottom} />
         </View>
       </ScrollView>
@@ -200,4 +209,4 @@ class FriendDetail extends Component<Props, State> {
 export default connect((state) => ({ user: getUser(state)(), pendingTransactions: pendingTransactions(state), getTwoPartyBalance: getTwoPartyBalance(state),
   recentTransactions: recentTransactions(state), calculateBalance: calculateBalance(state), convertCurrency: convertCurrency(state),
   primaryCurrency: getPrimaryCurrency(state), getPendingFromFriend: getPendingFromFriend(state) }),
-  { removeFriend })(FriendDetail)
+  { removeFriend, copyToClipboard })(FriendDetail)


### PR DESCRIPTION
In lieu of making it easier to transfer ERC-20 amongst friends and overall usefulness of Lndr, this PR adds the ability to view and copy your friend's wallet address. The address is hidden by default and visible by toggling the familiar disclosure arrow (same as My Account).
<img width="344" alt="image" src="https://user-images.githubusercontent.com/1081476/48592453-4cf08080-e8fd-11e8-950a-e7e8b74b60f2.png">
<img width="343" alt="image" src="https://user-images.githubusercontent.com/1081476/48592461-537ef800-e8fd-11e8-9722-f6be7359acb6.png">
