### PR TITLE
Lndr updates for BNB settlements

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -101,8 +101,8 @@ android {
         applicationId "com.lndr"
         minSdkVersion 16
         targetSdkVersion 27
-        versionCode 37
-        versionName "1.5.0"
+        versionCode 38
+        versionName "1.6.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }

--- a/ios/LNDR/Info.plist
+++ b/ios/LNDR/Info.plist
@@ -17,22 +17,17 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.50</string>
+	<string>1.60</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>50</string>
+	<string>52</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
 		</dict>
 	</dict>
 	<key>NSCameraUsageDescription</key>

--- a/packages/credit-protocol/index.ts
+++ b/packages/credit-protocol/index.ts
@@ -369,7 +369,7 @@ export default class CreditProtocol {
     })
   }
 
-  storeSettlementHash(txHash: any, hash: any, creditorAddress: string, privateKeyBuffer: any) {
+  storeSettlementHash(txHash: any, hash: string, creditorAddress: string, privateKeyBuffer: any) {
     const hashBuffer = Buffer.concat([
       hash,
       hexToBuffer(txHash),

--- a/packages/credit-protocol/lib/credit-record.ts
+++ b/packages/credit-protocol/lib/credit-record.ts
@@ -14,7 +14,7 @@ export default class CreditRecord {
 
   hash: any
 
-  constructor(ucacAddress: string, creditorAddress: string, debtorAddress: string, amount: number, memo: string, nonce: number) {
+  constructor(ucacAddress: string, creditorAddress: string, debtorAddress: string, amount: number, memo: string, nonce: number, hash?: string) {
     this.ucacAddress = ucacAddress
     this.creditorAddress = creditorAddress.replace('0x', '')
     this.debtorAddress = debtorAddress.replace('0x', '')
@@ -30,7 +30,7 @@ export default class CreditRecord {
       int32ToBuffer(nonce)
     ])
 
-    this.hash = ethUtil.sha3(buffer)
+    this.hash = hash ? hexToBuffer(hash) : ethUtil.sha3(buffer)
   }
 
   sign(privateKeyBuffer): String {

--- a/packages/lndr/pending-bilateral/index.ts
+++ b/packages/lndr/pending-bilateral/index.ts
@@ -15,7 +15,7 @@ export default class PendingBilateral {
     const { txHash } = data
     const { creditor, debtor, amount, memo, nonce, ucac, submitter, hash, settlementAmount, settlementCurrency, settlementBlocknumber, multiSettlements } = data.creditRecord
     this.submitter = submitter.replace('0x', '')
-    this.creditRecord = new CreditRecord(ucac, creditor, debtor, amount, memo, nonce)
+    this.creditRecord = new CreditRecord(ucac, creditor, debtor, amount, memo, nonce, hash)
     this.txHash = txHash
     this.settlementAmount = settlementAmount
     this.settlementBlocknumber = settlementBlocknumber

--- a/packages/ui/dialogs/settlement/index.tsx
+++ b/packages/ui/dialogs/settlement/index.tsx
@@ -225,8 +225,6 @@ class Settlement extends Component<Props, State> {
         )
       )
     } else {
-      console.log('AMOUNT SHOULD BE 50', amount)
-
       success = await submittingTransaction.wrap(
         this.props.addDebt(
           friend as Friend,

--- a/packages/ui/dialogs/settlement/index.tsx
+++ b/packages/ui/dialogs/settlement/index.tsx
@@ -225,6 +225,8 @@ class Settlement extends Component<Props, State> {
         )
       )
     } else {
+      console.log('AMOUNT SHOULD BE 50', amount)
+
       success = await submittingTransaction.wrap(
         this.props.addDebt(
           friend as Friend,


### PR DESCRIPTION
 1. Jira: https://blockmason.atlassian.net/secure/RapidBoard.jspa?rapidView=9&modal=detail&selectedIssue=LNDR-77

 2. Problem: Needed to update the version number and build number on Android and iOS, also had an issue with settlements when the amount was the entire amount but also in a different currency.

 3. Solution: Changed the logic for submitting a "multi-settlement" to include situations where the user is attempting to clear the entire balance of a debt/loan that is not in the user's primary currency. Is this situation, we can submit a list with a single transaction to the `multi-settlement` endpoint using the same logic as when there are multiple balances across different currencies.

 4. No trade-offs

 5. Server fix has already gone through and is confirmed to be working, no blockers