### PR TITLE
Shorten dynamic link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
+ios/Pods/
 
 # Android/IntelliJ
 #
@@ -57,19 +58,16 @@ buck-out/
 android/gradle.properties
 android/app/blockmason-lndr-android.keystore
 
+#ios config variables
+ios/AirshipConfig.plist
+ios/GoogleService-Info.plist
+ios/PayPalConfig.plist
+
 #android config variables
 android/app/google-services.json
 android/app/src/main/assets/airshipconfig.properties
 android/app/src/main/assets/index.android.bundle
 android/app/src/main/assets/paypalconfig.properties
-
-#aws secrets
-packages/lndr/profile-pic/config.json
-
-ios/AirshipConfig.plist
-ios/GoogleService-Info.plist
-ios/PayPalConfig.plist
-ios/Pods/
 
 #JEST
 .jest

--- a/README.md
+++ b/README.md
@@ -54,11 +54,16 @@ Log in to Firebase (https://console.firebase.google.com/u/0/project/lndr-english
 - `yarn` (this installs the packages)
 - Fill in the `.env.example` with the proper information and save as `.env`.
 - `yarn run setup:env`
+- Put 
 - (only need to do this once or if native dependencies change) `react-native link` (note it may hang on `rnpm-install info Assets have been successfully linked to your project` - it's ok to kill it then)
 - (in new terminal) `yarn run typescript`
 - (in new terminal) `yarn start`
 
 ## ... on iOS
+
+- Put `GoogleService-Info.plist` in `ios/`
+- Put `AirshipConfig.plist` in `ios/`
+- Put `PayPalConfig.plist` in `ios/`
 
 - `react-native run-ios`
 
@@ -72,8 +77,11 @@ Setting up ANDROID_HOME env variable
 
 <installation location> will be found in android studio (if installed) in Preferences -> Appearance & Behaviour -> System Settings -> Android SDK
 
-- Fill in the `.env.example` with the proper information and save as `.env`.
-- `yarn run setup:env`
+Config files
+- Put `google-services.json` in `android/app/`
+- Put `gradle.properties` in `android/`
+- Put `airshipconfig.properties` in `android/app/src/main/assets/`
+- Put `paypalconfig.properties` in `android/app/src/main/assets/`
 
 Running Android
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ Log in to Firebase (https://console.firebase.google.com/u/0/project/lndr-english
 - `yarn` (this installs the packages)
 - Fill in the `.env.example` with the proper information and save as `.env`. (info is in airshipconfig.properties or AirshipConfig.plist)
 - `yarn run setup:env`
-- Put 
-- (only need to do this once or if native dependencies change) `react-native link` (note it may hang on `rnpm-install info Assets have been successfully linked to your project` - it's ok to kill it then)
 - (in new terminal) `yarn run typescript`
 - (in new terminal) `yarn start`
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Log in to Firebase (https://console.firebase.google.com/u/0/project/lndr-english
 
 - Ensure that CocoaPods and Yarn are both installed (`sudo gem install cocoapods` and `brew install yarn`)
 - `yarn` (this installs the packages)
-- Fill in the `.env.example` with the proper information and save as `.env`.
+- Fill in the `.env.example` with the proper information and save as `.env`. (info is in airshipconfig.properties or AirshipConfig.plist)
 - `yarn run setup:env`
 - Put 
 - (only need to do this once or if native dependencies change) `react-native link` (note it may hang on `rnpm-install info Assets have been successfully linked to your project` - it's ok to kill it then)
@@ -64,6 +64,8 @@ Log in to Firebase (https://console.firebase.google.com/u/0/project/lndr-english
 - Put `GoogleService-Info.plist` in `ios/`
 - Put `AirshipConfig.plist` in `ios/`
 - Put `PayPalConfig.plist` in `ios/`
+
+- Run `cd ios && pod install && cd ..`
 
 - `react-native run-ios`
 

--- a/ios/LNDR/Info.plist
+++ b/ios/LNDR/Info.plist
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>58</string>
+	<string>59</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/packages/credit-protocol/index.ts
+++ b/packages/credit-protocol/index.ts
@@ -560,7 +560,6 @@ export default class CreditProtocol {
   }
 
   deleteEmailTx(hash: string) {
-    console.log('DELETING')
     return this.client.delete('/email_transaction/' + hash)
   }
 }

--- a/packages/credit-protocol/lib/credit-record.ts
+++ b/packages/credit-protocol/lib/credit-record.ts
@@ -21,7 +21,7 @@ export default class CreditRecord {
     this.debtorAddress = debtorAddress.replace('0x', '')
     this.amount = amount
     this.memo = memo
-    this.nonce = nonce
+    this.nonce = nonce || 0
     this.fromLink = fromLink
 
     const buffer = Buffer.concat([

--- a/packages/ui/views/confirmation/index.tsx
+++ b/packages/ui/views/confirmation/index.tsx
@@ -29,6 +29,9 @@ interface State {
 class ConfirmationScreen extends Component<Props, State> {
   constructor(props) {
     super(props)
+
+    this.goHome = this.goHome.bind(this)
+    this.goActivity = this.goActivity.bind(this)
   }
 
   componentDidMount( ) {
@@ -118,20 +121,20 @@ class ConfirmationScreen extends Component<Props, State> {
     return <View style={general.whiteFlex}>
       <View style={general.view}>
         <DashboardShell text={confirmation.shell} navigation={this.props.navigation} />
-        <BackButton onPress={() => this.goHome()} />
+        <BackButton onPress={this.goHome} />
       </View>
       <ScrollView style={[general.whiteFlex]} keyboardShouldPersistTaps="always">
         <View style={[general.centeredColumn, general.standardHMargin]}>
           {this.getConfirmationImage(type)}
           {this.displayMessage()}
           {type === 'erc20Sent' || type === 'confirmFriend' || type === 'rejectFriend' || type === 'kycSuccess' ? <View style={{marginBottom: 20}}/> :
-          <TouchableHighlight onPress={() => this.goActivity()}>
+          <TouchableHighlight onPress={this.goActivity}>
             <Text style={[style.text, style.spacing]}>
               <Text>{confirmation.status}</Text>
               <Text style={[style.text, style.link]}>{confirmation.activity}</Text>
             </Text>
           </TouchableHighlight>}
-          <Button fat wide round onPress={() => this.goHome()} text={confirmation.done} />
+          <Button fat wide round onPress={this.goHome} text={confirmation.done} />
         </View>
       </ScrollView>
     </View>

--- a/packages/ui/views/new-transaction/index.tsx
+++ b/packages/ui/views/new-transaction/index.tsx
@@ -102,18 +102,16 @@ class NewTransaction extends Component<Props, State> {
         const ucac = getUcacFromCurrency(currency)
         const inviteTx = new InviteTransaction({ address, amount, memo, ucac, direction, currency })
 
-        const buildLink = new firebase.links.DynamicLink(inviteTx.hash, 'lndr.page.link')
+        const buildLink = new firebase.links.DynamicLink('https://blockmason.io/lndr', 'lndr.page.link')
         buildLink
         .android.setPackageName('com.lndr')
-        .android.setFallbackUrl('https://play.google.com/store/apps/details?id=com.lndr')
         .ios.setAppStoreId('1322487591')
         .ios.setBundleId('io.lndr')
       
-        const url = await firebase.links().createDynamicLink(buildLink)
+        const url = await firebase.links().createShortDynamicLink(buildLink, "SHORT")
 
         const { action } : any = await Share.share({
-          message: `${splitExpense}: ${url}`,
-          url: url,
+          message: `${splitExpense}: ${url}?hash=${inviteTx.hash}`,
           title: splitExpense
         }, {
           dialogTitle: splitExpense // Android only

--- a/packages/ui/views/request-detail/index.tsx
+++ b/packages/ui/views/request-detail/index.tsx
@@ -242,7 +242,6 @@ class RequestDetail extends Component<Props, State> {
     let friendAddress = '', friend = new Friend('', ''), memo = '', isPayee = false, direction = 'lend'
 
     if (content instanceof InviteTransaction) {
-      console.log(content)
       direction = content.direction
       friend = new Friend(content.address, content.submitterNickname || '')
     }

--- a/packages/ui/views/request-detail/index.tsx
+++ b/packages/ui/views/request-detail/index.tsx
@@ -111,6 +111,8 @@ class RequestDetail extends Component<Props, State> {
     const { state: { content, transferLimitLevel }, props: { confirmPendingTransaction, confirmEmailTx, addDebt, ethExchange, ethSentPastWeek, user, primaryCurrency } }= this
     let success
 
+    console.log('CONTENT', content)
+
     if (content instanceof InviteTransaction) {
       success = await loadingContext.wrap(confirmEmailTx(content))
     } else if (content instanceof PendingTransaction) {
@@ -238,6 +240,12 @@ class RequestDetail extends Component<Props, State> {
       props: { user, primaryCurrency, settlerIsMe } } = this
 
     let friendAddress = '', friend = new Friend('', ''), memo = '', isPayee = false, direction = 'lend'
+
+    if (content instanceof InviteTransaction) {
+      console.log(content)
+      direction = content.direction
+      friend = new Friend(content.address, content.submitterNickname || '')
+    }
     
     if (content instanceof PendingTransaction || content instanceof InviteTransaction) {
       memo = content.memo.trim()


### PR DESCRIPTION
Problem: Dynamic links for sending transactions were too long
Solution: Generate a short dynamic link followed by the tx hash for linked transactions, and adjust the initialization code to use the new `hash` parameter